### PR TITLE
View Show.vwuPracticeIndex

### DIFF
--- a/migration_original/ODS1Stage/tables/Show/SOLRProviderAddress/spu_translated_SOLRProviderAddress.sql
+++ b/migration_original/ODS1Stage/tables/Show/SOLRProviderAddress/spu_translated_SOLRProviderAddress.sql
@@ -171,16 +171,16 @@ update_statement := '
 
 -- This is the merge statement from logic of show.spuSOLRProviderAddressGenerateFromMid                     
 merge_statement := '
-                   MERGE INTO DEV.SOLRProviderAddress USING 
+                   MERGE INTO Show.SOLRProviderAddress USING 
                    ('||select_statement||') as s 
-                   ON DEV.SOLRPROVIDERADDRESS.ProviderToOfficeID = s.ProviderToOfficeID
+                   ON Show.SOLRPROVIDERADDRESS.ProviderToOfficeID = s.ProviderToOfficeID
                    WHEN MATCHED THEN '||update_statement||'
                    WHEN NOT MATCHED THEN '||insert_statement||'
                    ';
 
 -- This delete comes from hack.spuRemoveSuspecProviders
 delete_statement := '
-                    DELETE FROM DEV.SOLRProviderAddress spa
+                    DELETE FROM Show.SOLRProviderAddress spa
                     USING Base.ProviderRemoval pr, Show.SOLRProvider sp
                     WHERE sp.ProviderCode = pr.ProviderCode
                     AND sp.ProviderID = spa.ProviderID

--- a/migration_original/ODS1Stage/views/Show/vwuPracticeIndex
+++ b/migration_original/ODS1Stage/views/Show/vwuPracticeIndex
@@ -1,0 +1,43 @@
+---------------------------------------------------------
+---------------- 0. View dependencies -------------------
+---------------------------------------------------------
+
+-- Show.vwuPracticeIndex depends on: 
+--- Show.SOLRPractice
+
+CREATE OR REPLACE VIEW ODS1_STAGE.SHOW.VWUPRACTICEINDEX(
+	PRACTICEID,
+	PRACTICECODE,
+	PRACTICEHGID,
+	PRACTICENAME,
+	YEARPRACTICEESTABLISHED,
+	PRACTICEEMAILXML,
+	PRACTICEWEBSITE,
+	PRACTICEDESCRIPTION,
+	PRACTICELOGO,
+	PRACTICEMEDICALDIRECTOR,
+	PHYSICIANCOUNT,
+	HASDENTIST,
+	OFFICEXML,
+	SPONSORSHIPXML
+) AS
+SELECT
+  p.PracticeID,
+  p.PracticeCode,
+  IFNULL(
+    p.LegacyKeyPractice,
+    'HGPPZ' || LEFT(REPLACE(p.PracticeID, '-', ''), 16)
+  ) AS PracticeHGID,
+  p.PracticeName,
+  p.YearPracticeEstablished,
+  p.PracticeEmailXML,
+  p.PracticeWebsite,
+  p.PracticeDescription,
+  p.PracticeLogo,
+  p.PracticeMedicalDirector,
+  p.PhysicianCount,
+  p.HasDentist,
+  p.OfficeXML,
+  p.SponsorshipXML
+FROM Show.SOLRPractice AS p
+WHERE p.OfficeXML IS NOT NULL;


### PR DESCRIPTION
View was validated with our validation method in the utils.py. This is the output of the validation unit test:

- Percentage of Identical Columns: 78.57% (11/14)
- Percentage of Different Columns: 21.43% (3/14). See example below 

1. The different columns are because the view only uses Show.SOLRPractice as source and this table is still IN DEV (its load stored procedure has not been pushed to main). Mismatch occurs in OFFICEXML and SPONSORSHIPXML columns as expected since there is still ongoing debugging with XML. 
2. The other difference was PHYSICIANCOUNT column. This is interesting because this column comes directly from Show.SOLRPractice and my best bet would that the data underlying source data used to generate Show.SOLRPractice from Mid has changed in SQL Server (since PracticeID is a true primary key). 
