### PR TITLE
Mid.ProviderCondition

### DIFF
--- a/migration_original/ODS1Stage/tables/Mid/ProviderCondition/spu_original_ProviderCondition.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderCondition/spu_original_ProviderCondition.sql
@@ -1,0 +1,125 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER procedure [Mid].[spuProviderConditionRefresh]
+(
+    @IsProviderDeltaProcessing bit = 0
+)
+as
+
+/*
+    Created By:		John Tran
+	Created On:		12/30/2011	
+
+	Reoccurence:	This stored procedure will INSERT/UPDATE/DELETE data from the Mid.ProviderCondition table that is used for the Provider SOLR Core
+
+	Updated By:		Zafer Faddah
+	Updated On:		08/27/2014
+	Update Note:	Replaced dbo.Individual with src.Provider 
+
+	Test:			EXEC Mid.spuProviderConditionRefresh
+						
+*/
+
+
+declare @ErrorMessage varchar(1000)
+
+begin try
+        IF OBJECT_ID('tempdb..#ProviderBatch') IS NOT NULL DROP TABLE #ProviderBatch 
+        CREATE TABLE #ProviderBatch (ProviderID uniqueidentifier)
+        
+        IF @IsProviderDeltaProcessing = 0
+		BEGIN
+            INSERT INTO #ProviderBatch (ProviderID) SELECT a.ProviderID FROM Base.Provider a ORDER BY a.ProviderID
+        END
+        ELSE
+		BEGIN
+            INSERT INTO #ProviderBatch (ProviderID)
+            SELECT	a.ProviderID
+            FROM	Snowflake.etl.ProviderDeltaProcessing as a
+        END
+
+	--build a temp table with the same structure as the Mid.ProviderCondition
+		IF OBJECT_ID('tempdb..#ProviderCondition') IS NOT NULL DROP TABLE #ProviderCondition
+        SELECT TOP 0 *
+		INTO	#ProviderCondition
+		FROM	Mid.ProviderCondition
+		
+		ALTER TABLE #ProviderCondition
+		ADD ActionCode int default 0
+		
+		CREATE CLUSTERED INDEX [CIX_TempProviderBatchConditionProviderId]	ON #ProviderBatch([ProviderID])
+
+	--populate the temp table with data from Base schemas
+		INSERT INTO	#ProviderCondition (ProviderToConditionID,ProviderID,ConditionCode,ConditionDescription,ConditionGroupDescription,LegacyKey)
+		SELECT		a.EntityToMedicalTermID as ProviderToConditionID, a.EntityID as ProviderID, b.MedicalTermCode as ConditionCode, b.MedicalTermDescription1 as ConditionDescription, b.MedicalTermDescription2 ConditionGroupDescription, b.LegacyKey
+		FROM		#ProviderBatch as pb 
+		INNER JOIN	Base.EntityToMedicalTerm as a with (nolock) 
+					on a.EntityID = pb.ProviderID
+		INNER JOIN	Base.MedicalTerm as b with (nolock) 
+					on b.MedicalTermID = a.MedicalTermID
+		INNER JOIN	Base.EntityType as d with (nolock) 
+					on d.EntityTypeID = a.EntityTypeID
+		INNER JOIN	Base.MedicalTermSet as e with (nolock) 
+					on e.MedicalTermSetID = b.MedicalTermSetID
+		INNER JOIN	Base.MedicalTermType as f with (nolock) 
+					on f.MedicalTermTypeID = b.MedicalTermTypeID
+		WHERE		e.MedicalTermSetCode = 'HGProvider'
+					and f.MedicalTermTypeCode = 'Condition'
+		
+		CREATE INDEX temp on #ProviderCondition (ProviderToConditionID)
+
+        IF @IsProviderDeltaProcessing = 1
+		BEGIN
+			/*Updates*/
+			UPDATE		A
+			SET			a.ConditionCode = b.ConditionCode,
+						a.ConditionDescription = b.ConditionDescription,
+						a.ConditionGroupDescription = b.ConditionGroupDescription,
+						a.LegacyKey = b.LegacyKey,
+						a.ProviderID = b.ProviderID
+			FROM		#ProviderCondition a
+			INNER JOIN	Mid.ProviderCondition b with (nolock) 
+						ON (a.ProviderToConditionID = b.ProviderToConditionID)
+			WHERE		BINARY_CHECKSUM(isnull(cast(a.ConditionCode as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ConditionCode as varchar(max)),''))
+						OR BINARY_CHECKSUM(isnull(cast(a.ConditionDescription as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ConditionDescription as varchar(max)),''))
+						OR BINARY_CHECKSUM(isnull(cast(a.ConditionGroupDescription as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ConditionGroupDescription as varchar(max)),''))
+						OR BINARY_CHECKSUM(isnull(cast(a.LegacyKey as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.LegacyKey as varchar(max)),''))
+						OR BINARY_CHECKSUM(isnull(cast(a.ProviderID as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ProviderID as varchar(max)),''))
+
+			/*Inserts*/
+			INSERT INTO Mid.ProviderCondition (ConditionCode,ConditionDescription,ConditionGroupDescription,LegacyKey,ProviderID,ProviderToConditionID)
+			SELECT		A.ConditionCode, A.ConditionDescription, A.ConditionGroupDescription, A.LegacyKey, A.ProviderID, A.ProviderToConditionID 
+			FROM		#ProviderCondition A
+			LEFT JOIN	Mid.ProviderCondition B
+						ON a.ProviderToConditionID = b.ProviderToConditionID
+			WHERE		b.ProviderToConditionID is null
+			
+			/*Deletes*/
+			DELETE		A
+			--select *
+			FROM		Mid.ProviderCondition a with (nolock)
+            INNER JOIN	#ProviderBatch as pb 
+						on pb.ProviderID = a.ProviderID	
+			LEFT JOIN	#ProviderCondition b 
+						on (a.ProviderToConditionID = b.ProviderToConditionID)
+			WHERE		b.ProviderToConditionID is null
+	
+		END
+
+        IF @IsProviderDeltaProcessing = 0
+		BEGIN
+			/*Full Inserts*/
+			TRUNCATE TABLE Mid.ProviderCondition 
+			INSERT INTO Mid.ProviderCondition (ConditionCode,ConditionDescription,ConditionGroupDescription,LegacyKey,ProviderID,ProviderToConditionID)
+			SELECT		A.ConditionCode, A.ConditionDescription, A.ConditionGroupDescription, A.LegacyKey, A.ProviderID, A.ProviderToConditionID 
+			FROM		#ProviderCondition A
+		END
+
+end try
+begin catch
+    set @ErrorMessage = 'Error in procedure Mid.spuProviderConditionRefresh, line ' + convert(varchar(20), error_line()) + ': ' + error_message()
+    raiserror(@ErrorMessage, 18, 1)
+end catch
+GO

--- a/migration_original/ODS1Stage/tables/Mid/ProviderCondition/spu_translated_ProviderCondition.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderCondition/spu_translated_ProviderCondition.sql
@@ -1,0 +1,175 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.Mid.SP_LOAD_PROVIDERCONDITION(IsProviderDeltaProcessing BOOLEAN)
+RETURNS VARCHAR(16777216)
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS 
+
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+
+-- Base.Provider
+-- Base.EntityToMedicalTerm
+-- Base.MedicalTerm
+-- Base.EntityType
+-- Base.MedicalTermSet
+-- Base.MedicalTermType
+-- raw.ProviderDeltaProcessing
+-- Mid.ProviderCondition (*)
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+DECLARE
+
+select_statement STRING; 
+insert_statement STRING;
+merge_statement STRING; 
+status STRING;
+
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------  
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------  
+
+-- The conditional statements are included in this block since 
+-- the conditional itself directly determines the select
+
+BEGIN
+
+      IF (IsProviderDeltaProcessing) THEN
+        select_statement := $$
+                            (WITH CTE_ProviderBatch AS (
+                                SELECT pdp.ProviderID
+                                FROM raw.ProviderDeltaProcessing AS pdp
+                                ORDER BY pdp.ProviderID
+                            ),
+                            
+                            CTE_ProviderCondition AS (
+                                SELECT
+                                    etmt.EntityToMedicalTermID AS ProviderToConditionID,
+                                    etmt.EntityID AS ProviderID,
+                                    mt.MedicalTermCode AS ConditionCode,
+                                    mt.MedicalTermDescription1 AS ConditionDescription,
+                                    mt.MedicalTermDescription2 AS ConditionGroupDescription,
+                                    mt.LegacyKey
+                                FROM CTE_ProviderBatch AS pb
+                                INNER JOIN Base.EntityToMedicalTerm AS etmt ON etmt.EntityID = pb.ProviderID 
+                                INNER JOIN Base.MedicalTerm AS mt ON mt.MedicalTermID = etmt.MedicalTermID
+                                INNER JOIN Base.EntityType AS et ON et.EntityTypeID = etmt.EntityTypeID
+                                INNER JOIN Base.MedicalTermSet AS mts ON mts.MedicalTermSetID = mt.MedicalTermSetID
+                                INNER JOIN Base.MedicalTermType AS mtt ON mtt.MedicalTermTypeID = mt.MedicalTermTypeID
+                                INNER JOIN Mid.ProviderCondition AS mpc ON etmt.EntityToMedicalTermID = mpc.ProviderToConditionID
+                                WHERE mts.MedicalTermSetCode = 'HGProvider' AND mtt.MedicalTermTypeCode = 'Condition'
+                                 AND (MD5(IFNULL(CAST(mt.MedicalTermCode AS VARCHAR), '')) <> MD5(IFNULL(CAST(mpc.ConditionCode AS VARCHAR), '')) OR 
+                                      MD5(IFNULL(CAST(mt.MedicalTermDescription1 AS VARCHAR), '')) <> MD5(IFNULL(CAST(mpc.ConditionDescription AS VARCHAR), '')) OR 
+                                      MD5(IFNULL(CAST(mt.MedicalTermDescription2 AS VARCHAR), '')) <> MD5(IFNULL(CAST(mpc.ConditionGroupDescription AS VARCHAR), '')) OR 
+                                      MD5(IFNULL(CAST(mt.LegacyKey AS VARCHAR), '')) <> MD5(IFNULL(CAST(mpc.LegacyKey AS VARCHAR), '')) OR 
+                                      MD5(IFNULL(CAST(etmt.EntityID AS VARCHAR), '')) <> MD5(IFNULL(CAST(mpc.ProviderID AS VARCHAR), '')))
+                             ) 
+                             
+                             SELECT
+                              pc.ConditionCode,
+                              pc.ConditionDescription,
+                              pc.ConditionGroupDescription,
+                              pc.LegacyKey,
+                              pc.ProviderID,
+                              pc.ProviderToConditionID
+                             FROM CTE_ProviderCondition pc)
+                            $$;
+                            
+      ELSE
+        select_statement := $$
+                            (WITH CTE_ProviderBatch AS (
+                              SELECT p.ProviderID
+                              FROM Base.Provider AS p
+                              ORDER BY p.ProviderID
+                            ),
+                            
+                            CTE_ProviderCondition AS (
+                              SELECT
+                                etmt.EntityToMedicalTermID AS ProviderToConditionID,
+                                etmt.EntityID AS ProviderID,
+                                mt.MedicalTermCode AS ConditionCode,
+                                mt.MedicalTermDescription1 AS ConditionDescription,
+                                mt.MedicalTermDescription2 AS ConditionGroupDescription,
+                                mt.LegacyKey
+                              FROM CTE_ProviderBatch AS pb
+                              INNER JOIN Base.EntityToMedicalTerm AS etmt ON etmt.EntityID = pb.ProviderID 
+                              INNER JOIN Base.MedicalTerm AS mt ON mt.MedicalTermID = etmt.MedicalTermID
+                              INNER JOIN Base.EntityType AS et ON et.EntityTypeID = etmt.EntityTypeID
+                              INNER JOIN Base.MedicalTermSet AS mts ON mts.MedicalTermSetID = mt.MedicalTermSetID
+                              INNER JOIN Base.MedicalTermType AS mtt ON mtt.MedicalTermTypeID = mt.MedicalTermTypeID
+                              WHERE mts.MedicalTermSetCode = 'HGProvider' AND mtt.MedicalTermTypeCode = 'Condition'
+                            )
+                            
+                            SELECT
+                              pc.ConditionCode,
+                              pc.ConditionDescription,
+                              pc.ConditionGroupDescription,
+                              pc.LegacyKey,
+                              pc.ProviderID,
+                              pc.ProviderToConditionID
+                            FROM CTE_ProviderCondition pc)
+                            $$;
+      END IF;
+      
+
+      ---------------------------------------------------------
+      --------- 4. Actions (Inserts and Updates) --------------
+      ---------------------------------------------------------
+      insert_statement := $$
+                         INSERT 
+                          ( 
+                          ConditionCode,
+                          ConditionDescription,
+                          ConditionGroupDescription,
+                          LegacyKey,
+                          ProviderID,
+                          ProviderToConditionID
+                          )
+                         VALUES 
+                          (
+                          source.ConditionCode,
+                          source.ConditionDescription,
+                          source.ConditionGroupDescription,
+                          source.LegacyKey,
+                          source.ProviderID,
+                          source.ProviderToConditionID
+                          )
+                          $$;
+
+
+      merge_statement := $$
+                        MERGE INTO Mid.ProviderCondition AS target 
+                        USING $$ || select_statement || $$ AS source	
+                        ON source.ProviderToConditionID = target.ProviderToConditionID
+                        WHEN MATCHED AND target.ProviderToConditionID = source.ProviderToConditionID
+                                     AND source.ProviderID = target.ProviderID 
+                                     AND source.ProviderToConditionID IS NULL THEN DELETE
+                        WHEN NOT MATCHED THEN $$ || insert_statement;
+
+    ---------------------------------------------------------
+    ------------------- 5. Execution ------------------------
+    --------------------------------------------------------- 
+     
+    EXECUTE IMMEDIATE merge_statement;
+                        
+    ---------------------------------------------------------
+    --------------- 6. Status monitoring --------------------
+    --------------------------------------------------------- 
+    
+    status := 'Completed successfully';
+        RETURN status;
+    
+    
+    EXCEPTION
+        WHEN OTHER THEN
+              status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+              RETURN status;
+                    
+END;


### PR DESCRIPTION
In original SQL Server code the temporary table created in runtime is updated using the current Mid.Provider table for some reason (lines 76-89). This logic was moved to the CTE_ProviderCondition WHERE statement (lines 68-72 in translated version). Otherwise this one was straightforward. 