### PR TITLE
provider affiliation

### DIFF
--- a/migration_original/ODS1Stage/tables/Mid/ProviderAffiliation/spu_original_ProviderAffiliation.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderAffiliation/spu_original_ProviderAffiliation.sql
@@ -1,0 +1,189 @@
+-- mid.spuprovideraffiliationrefresh
+
+if @IsProviderDeltaProcessing = 0 begin
+            insert into #ProviderBatch (ProviderID) select a.ProviderID from Base.Provider as a order by a.ProviderID
+          end
+        else begin
+            insert into #ProviderBatch (ProviderID)
+            select a.ProviderID
+            from Snowflake.etl.ProviderDeltaProcessing as a
+        end
+
+	--build a temp table with the same structure as the Mid.ProviderAffiliation
+		begin try drop table #ProviderAffiliation end try begin catch end catch
+		select top 0 *
+		into #ProviderAffiliation
+		from Mid.ProviderAffiliation
+		
+		alter table #ProviderAffiliation
+		add ActionCode int default 0
+		
+	--populate the temp table with data from Base schemas
+		insert into #ProviderAffiliation 
+			(
+				ProviderToAffiliationID,ProviderID,AffiliationBeginDate,AffiliationEndDate,AffiliationName,
+				AffiliationTypeCode,AffiliationTypeDescription,RoleCode,RoleDescription
+			)
+		select a.ProviderToAffiliationID,a.ProviderID, a.AffiliationBeginDate, a.AffiliationEndDate, a.AffiliationName, 
+		b.AffiliationTypeCode, b.AffiliationTypeDescription, c.RoleCode, c.RoleDescription
+		from #ProviderBatch as pb  --When not migrating a batch, this is all providers in Base.Provider. Otherwise it is just the providers in the batch
+		inner join Base.ProviderToAffiliation as a with (nolock) on a.ProviderID = pb.ProviderID
+		inner join Base.Affiliation as b with (nolock) on a.AffiliationID = b.AffiliationID
+		inner join Base.ProviderRole as c with (nolock) on a.ProviderRoleID = c.ProviderRoleID
+		
+		create index temp on #ProviderAffiliation (ProviderToAffiliationID)
+
+	/*
+		Flag record level actions for ActionCode
+			0 = No Change
+			1 = Insert
+			2 = Update
+	*/
+		--ActionCode Insert
+			update a
+			set a.ActionCode = 1
+			--select *
+			from #ProviderAffiliation a
+			left join Mid.ProviderAffiliation b on (a.ProviderToAffiliationID = b.ProviderToAffiliationID)
+			where b.ProviderToAffiliationID is null
+		
+		--ActionCode Update
+			begin try drop table #ColumnsUpdates end try begin catch end catch
+			
+			select name, identity(int,1,1) as recId
+			into #ColumnsUpdates
+			from tempdb..syscolumns 
+			where id = object_id('TempDB..#ProviderAffiliation')
+			and name not in ('ProviderToAffiliationID'/*PK*/, 'ActionCode')
+				
+			--build the sql statement with dynamic sql to check if we need to update any columns
+				declare @sql varchar(8000)
+				declare @min int
+				declare @max int
+				declare @whereClause varchar(8000)
+				declare @column varchar(100)
+				declare @newline char(1)
+				declare @globalCheck varchar(3)
+
+				set @min = 1
+				set @whereClause = ''
+				set @newline = char(10)
+				set @sql = 'update a'+@newline+ 
+						   'set a.ActionCode = 2'+@newline+
+						   '--select *'+@newline+
+						   'from #ProviderAffiliation a'+@newline+
+						   'join Mid.ProviderAffiliation b with (nolock) on (a.ProviderToAffiliationID = b.ProviderToAffiliationID)'+@newline+
+						   'where '
+						   
+				select @max = MAX(recId) from #ColumnsUpdates
+
+				while @min <= @max	
+					begin
+						select @column = name from #ColumnsUpdates where recId = @min 
+						set @whereClause = @whereClause +'BINARY_CHECKSUM(isnull(cast(a.'+@column+' as varchar(max)),'''')) <> BINARY_CHECKSUM(isnull(cast(b.'+@column+' as varchar(max)),''''))'+@newline
+							--put an OR for all except for the last column check
+							if @min < @max 
+								begin
+									set @whereClause = @whereClause+' or '
+								end
+
+						
+						set @min = @min + 1
+					end
+
+				set @sql = @sql + @whereClause
+				exec (@sql)
+
+	/*
+		Complete the ActionCode
+	*/
+	
+		--define column set for INSERTS 
+		begin try drop table #ColumnInserts end try begin catch end catch
+
+		select name, identity(int,1,1) as recId
+		into #ColumnInserts
+		from tempdb..syscolumns 
+		where id = object_id('TempDB..#ProviderAffiliation')
+		and name <> 'ActionCode'--do not need to insert/update this field
+		
+		--create the column set
+		declare @columnInsert varchar(100)
+		declare @columnListInsert varchar(8000)
+		declare @minInsert int
+		declare @maxInsert int
+		
+		set @minInsert = 1
+		set @columnListInsert = ''
+		select @maxInsert = MAX(recId) from #ColumnInserts 
+		
+		while @minInsert <= @maxInsert
+			begin
+				select @columnInsert = name from #ColumnInserts where recId = @minInsert
+				set @columnListInsert = @columnListInsert + @columnInsert
+				
+				if @minInsert <@maxInsert
+					begin
+						set @columnListInsert = @columnListInsert+','
+					end
+				
+				set @minInsert = @minInsert + 1
+			end
+		
+		--ActionCode = 1 (Inserts)
+			declare @sqlInsert varchar(8000)
+			set @sqlInsert = 
+			'insert into Mid.ProviderAffiliation ('+@columnListInsert+')
+			select '+@columnListInsert+' from #ProviderAffiliation where ActionCode = 1'
+			
+			exec (@sqlInsert)
+		
+		--ActionCode = 2 (Updates)	
+			declare @minUpdates int
+			declare @maxUpdates int
+			declare @sqlUpdates varchar(8000)
+			declare @sqlUpdatesClause varchar(500)
+			declare @columnUpdates varchar(150)
+			declare @columnListUpdates varchar(8000)
+			declare @newlineUpdates char(1)
+			
+			set @newlineUpdates = char(10)
+			set @columnListUpdates = ''
+			set @sqlUpdates = 'update a'+@newlineUpdates+
+							  'set '	
+			set @sqlUpdatesClause = '--select *'+@newlineUpdates+
+							  'from Mid.ProviderAffiliation a with (nolock)'+@newlineUpdates+
+							  'join #ProviderAffiliation b on (a.ProviderToAffiliationID = b.ProviderToAffiliationID)'+@newlineUpdates+
+							  'where b.ActionCode = 2'
+							  
+			select @minUpdates = MIN(recId) from #ColumnsUpdates 
+			select @maxUpdates = MAX(recId) from #ColumnsUpdates
+			
+			while @minUpdates <= @maxUpdates
+				begin
+					select @columnUpdates = name from #ColumnsUpdates where recId = @minUpdates
+					set @columnListUpdates = @columnListUpdates + 'a.'+@columnUpdates+' = b.'+@columnUpdates
+					
+					if @minUpdates < @maxUpdates
+						begin
+							set @columnListUpdates = @columnListUpdates+','+@newlineUpdates+''
+						end
+					else
+						begin
+							set @columnListUpdates = @columnListUpdates+@newlineUpdates+@sqlUpdatesClause
+						end
+					
+					set @minUpdates = @minUpdates + 1
+				end
+			
+			set @sqlUpdates = @sqlUpdates + @columnListUpdates
+			
+			exec (@sqlUpdates)
+
+		--ActionCode = N (Deletes)
+			delete a
+			--select *
+			from Mid.ProviderAffiliation a with (nolock)
+            inner join #ProviderBatch as pb on pb.ProviderID = a.ProviderID	
+			left join #ProviderAffiliation b on (a.ProviderToAffiliationID = b.ProviderToAffiliationID)
+			where b.ProviderToAffiliationID is null

--- a/migration_original/ODS1Stage/tables/Mid/ProviderAffiliation/spu_translated_ProviderAffiliation.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderAffiliation/spu_translated_ProviderAffiliation.sql
@@ -1,0 +1,200 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.MID.SP_LOAD_PROVIDERAFFILIATION(IsProviderDeltaProcessing BOOLEAN) -- Parameters
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+    
+-- Mid.ProviderAffiliation depends on: 
+--- Raw.ProviderDeltaProcessing
+--- Base.Provider
+--- Base.ProviderToAffiliation
+--- Base.Affiliation
+--- Base.ProviderRole
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+    select_statement STRING; -- CTE and Select statement for the Merge
+    update_statement STRING; -- Update statement for the Merge
+    insert_statement STRING; -- Insert statement for the Merge
+    merge_statement STRING; -- Merge statement to final table
+    status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    IF (IsProviderDeltaProcessing) THEN
+           select_statement := '
+          WITH CTE_ProviderBatch AS (
+                SELECT
+                    pdp.ProviderID
+                FROM
+                    Raw.ProviderDeltaProcessing as pdp),';
+    ELSE
+           select_statement := '
+           WITH CTE_ProviderBatch AS (
+                SELECT
+                    p.ProviderID
+                FROM
+                    Base.Provider AS p
+                ORDER BY
+                    p.ProviderID),';
+    END IF;
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+--- Select Statement
+
+-- If conditionals:
+select_statement := select_statement || 
+                    $$ CTE_ProviderAffiliation AS (
+                            SELECT
+                                pta.ProviderToAffiliationID,
+                                pta.ProviderID,
+                                pta.AffiliationBeginDate,
+                                pta.AffiliationEndDate,
+                                pta.AffiliationName,
+                                aff.AffiliationTypeCode,
+                                aff.AffiliationTypeDescription,
+                                pr.RoleCode,
+                                pr.RoleDescription,
+                                0 AS ActionCode
+                            FROM
+                                CTE_ProviderBatch AS pb
+                                JOIN Base.ProviderToAffiliation AS pta ON pta.ProviderID = pb.ProviderID
+                                JOIN Base.Affiliation AS aff ON pta.AffiliationID = aff.AffiliationID
+                                JOIN Base.ProviderRole AS pr ON pta.ProviderRoleID = pr.ProviderRoleID
+                        ),
+                        -- Insert Action
+                        CTE_Action_1 AS (
+                            SELECT
+                                cte.ProviderToAffiliationID,
+                                1 AS ActionCode
+                            FROM
+                                CTE_ProviderAffiliation AS cte
+                                LEFT JOIN Mid.ProviderAffiliation AS mid ON cte.ProviderToAffiliationID = mid.ProviderToAffiliationID
+                            WHERE
+                                mid.ProviderToAffiliationID IS NULL
+                        ),
+                        -- Update Action
+                        CTE_Action_2 AS (
+                            SELECT
+                                cte.ProviderToAffiliationID,
+                                2 AS ActionCode
+                            FROM
+                                CTE_ProviderAffiliation AS cte
+                                LEFT JOIN Mid.ProviderAffiliation AS mid ON cte.ProviderToAffiliationID = mid.ProviderToAffiliationID
+                            WHERE
+                                MD5(IFNULL(cte.ProviderID::VARCHAR, '')) <> MD5(IFNULL(mid.ProviderID::VARCHAR, '')) OR
+                                MD5(IFNULL(cte.AffiliationBeginDate::VARCHAR, '')) <> MD5(IFNULL(mid.AffiliationBeginDate::VARCHAR, ''))  OR
+                                MD5(IFNULL(cte.AffiliationEndDate::VARCHAR, '')) <> MD5(IFNULL(mid.AffiliationEndDate::VARCHAR, ''))  OR
+                                MD5(IFNULL(cte.AffiliationName::VARCHAR, '')) <> MD5(IFNULL(mid.AffiliationName::VARCHAR, '')) OR
+                                MD5(IFNULL(cte.AffiliationTypeCode::VARCHAR, '')) <> MD5(IFNULL(mid.AffiliationTypeCode::VARCHAR, '')) OR
+                                MD5(IFNULL(cte.AffiliationTypeDescription::VARCHAR, '')) <> MD5(IFNULL(mid.AffiliationTypeDescription::VARCHAR, '')) OR
+                                MD5(IFNULL(cte.RoleCode::VARCHAR, '')) <> MD5(IFNULL(mid.RoleCode::VARCHAR, ''))OR
+                                MD5(IFNULL(cte.RoleDescription::VARCHAR, '')) <> MD5(IFNULL(mid.RoleDescription::VARCHAR, '')) 
+                        
+                        )
+                        SELECT
+                            A0.ProviderToAffiliationID,
+                            A0.ProviderID,
+                            A0.AffiliationBeginDate,
+                            A0.AffiliationEndDate,
+                            A0.AffiliationName,
+                            A0.AffiliationTypeCode,
+                            A0.AffiliationTypeDescription,
+                            A0.RoleCode,
+                            A0.RoleDescription,
+                            IFNULL(
+                                A1.ActionCode,
+                                IFNULL(A2.ActionCode, A0.ActionCode)
+                            ) AS ActionCode
+                        FROM
+                            CTE_ProviderAffiliation AS A0
+                            LEFT JOIN CTE_Action_1 AS A1 ON A0.ProviderToAffiliationID = A1.ProviderToAffiliationID
+                            LEFT JOIN CTE_Action_2 AS A2 ON A0.ProviderToAffiliationID = A2.ProviderToAffiliationID
+                        WHERE
+                            IFNULL(
+                                A1.ActionCode,
+                                IFNULL(A2.ActionCode, A0.ActionCode)
+                            ) <> 0 $$;
+
+--- Update Statement
+update_statement := ' UPDATE 
+                     SET 
+                        ProviderToAffiliationID = source.ProviderToAffiliationID,
+                        ProviderID = source.ProviderID,
+                        AffiliationBeginDate = source.AffiliationBeginDate,
+                        AffiliationEndDate = source.AffiliationEndDate,
+                        AffiliationName = source.AffiliationName,
+                        AffiliationTypeCode = source.AffiliationTypeCode,
+                        AffiliationTypeDescription = source.AffiliationTypeDescription,
+                        RoleCode = source.RoleCode,
+                        RoleDescription = source.RoleDescription';
+
+--- Insert Statement
+insert_statement := ' INSERT  (
+                            ProviderToAffiliationID,
+                            ProviderID,
+                            AffiliationBeginDate,
+                            AffiliationEndDate,
+                            AffiliationName,
+                            AffiliationTypeCode,
+                            AffiliationTypeDescription,
+                            RoleCode,
+                            RoleDescription)
+                      VALUES (
+                            source.ProviderToAffiliationID,
+                            source.ProviderID,
+                            source.AffiliationBeginDate,
+                            source.AffiliationEndDate,
+                            source.AffiliationName,
+                            source.AffiliationTypeCode,
+                            source.AffiliationTypeDescription,
+                            source.RoleCode,
+                            source.RoleDescription)';
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+
+merge_statement := ' MERGE INTO Mid.ProviderAffiliation as target USING 
+                   ('||select_statement||') as source 
+                   ON source.ProviderToAffiliationID = target.ProviderToAffiliationID
+                   WHEN MATCHED AND source.ActionCode = 2 THEN '||update_statement|| '
+                   WHEN NOT MATCHED AND source.ActionCode = 1 THEN '||insert_statement;
+                   
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+                    
+EXECUTE IMMEDIATE merge_statement ;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+
+    
+END;


### PR DESCRIPTION
The table mid.provideraffiliation is empty so it is hard to validate
This is because it takes data from base tables that are also empty like: base.affiliation and base.providertoaffiliation
The procedure that updates this table is executed in the main job, but then this table is not used for any other table update so I would say there is no need to actually migrate this in snowflake