### PR TITLE
Mid.ProviderPracticeOffice

### DIFF
--- a/migration_original/ODS1Stage/tables/Mid/ProviderPracticeOffice/spu_original_ProviderPracticeOffice.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderPracticeOffice/spu_original_ProviderPracticeOffice.sql
@@ -1,0 +1,362 @@
+-- this comes from etl_spuMidProviderEntityRefresh
+update Mid.ProviderPracticeOffice
+SET CITY = LEFT(CITY,LEN(CITY)-1)
+where City+', '+ State like '%,,%'
+
+-- this comes from Mid_spuProviderPracticeOfficeRefresh
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+ALTER   procedure [Mid].[spuProviderPracticeOfficeRefresh]
+(
+    @IsProviderDeltaProcessing bit = 0
+)
+as
+
+declare @ErrorMessage varchar(1000)
+
+begin try
+
+		--THIS IS A TEMPORARY HACK/SOLUTION UNTIL THE "DUPLICATION ADDRESSES ARE FIXED"
+		--WE ARE KEYING OFF OF THE PROVIDEROFFICEID TO MAKE UPDATES TO AND THIS IS CAUSING ISSUES
+		--REMOVE THIS LATER!!!!!!!
+			if @IsProviderDeltaProcessing = 0
+				begin
+					TRUNCATE TABLE Mid.ProviderPracticeOffice
+					print 'truncate mid.ProviderPracticeOffice'
+				END
+			else
+				begin
+					delete ppo --Mid.ProviderPracticeOffice
+					from Snowflake.etl.ProviderDeltaProcessing as a
+						inner join Mid.ProviderPracticeOffice ppo on a.ProviderID = ppo.ProviderID	
+				END
+ 		
+
+
+    --Create & fill table that holds the list of provider records that were supposed to migrate with the batch.  
+    --  If this is a full file refresh, migrate all Base.Provider records.
+    --  If this is a batch migration, the list records comes from provider deltas
+    --  Obviously, if this is a full file refresh then technically a list of the records that migrated isn't neccessary, but it makes
+    --      the code that inserts into #Provider much simpler as it removes the need for separate insert queries or dynamic SQL
+
+        begin try drop table #ProviderBatch end try begin catch end catch
+        create table #ProviderBatch (ProviderID uniqueidentifier)
+        
+        if @IsProviderDeltaProcessing = 0 begin
+            insert into #ProviderBatch (ProviderID) 
+			select a.ProviderID 
+			from Base.Provider as a 
+			--where providercode = '3t345'
+			order by a.ProviderID
+          end
+        else begin
+			insert into #ProviderBatch (ProviderID)
+            select a.ProviderID
+            from Snowflake.etl.ProviderDeltaProcessing as a
+        end
+        
+        create clustered index tmp_clu_ix on #ProviderBatch (ProviderID)
+
+	--build a temp table with the same structure as the Mid.ProviderPracticeOffice
+		begin try drop table #ProviderPracticeOffice end try begin catch end catch
+		select top 0 *
+		into #ProviderPracticeOffice
+		from Mid.ProviderPracticeOffice
+		
+		alter table #ProviderPracticeOffice
+		add ActionCode int default 0
+		
+	--populate the temp table with data from Base schemas
+		--exec hack.spuGetSourceOfficePracticeNames --HACK to ensure the source PracticeName and OfficeName go out to the web
+
+		insert into #ProviderPracticeOffice 
+			(
+				ProviderToOfficeID,ProviderID,PracticeID,PracticeCode,PracticeName,YearPracticeEstablished,PracticeNPI,
+				PracticeEmail,PracticeWebsite,PracticeDescription,PracticeLogo,PracticeMedicalDirector,PracticeSoftware,
+				PracticeTIN,OfficeToAddressID,OfficeID,OfficeCode,OfficeName,IsPrimaryOffice,ProviderOfficeRank,AddressID,AddressCode,AddressTypeCode,AddressLine1,
+				AddressLine2,AddressLine3,AddressLine4,City,State,ZipCode,County,Nation,Latitude,Longitude,FullPhone,FullFax,IsDerived,
+				HasBillingStaff,HasHandicapAccess,HasLabServicesOnSite,HasPharmacyOnSite,HasXrayOnSite,IsSurgeryCenter,HasSurgeryOnSite,
+				AverageDailyPatientVolume,PhysicianCount,OfficeCoordinatorName,ParkingInformation,PaymentPolicy,LegacyKeyOffice,LegacyKeyPractice
+			)
+        select distinct --a.OfficeName, b.OfficeName, a.PracticeName, g.PracticeName,
+                a.ProviderToOfficeID, a.ProviderID, g.PracticeID, g.PracticeCode, 
+				case when a.PracticeName is not null then a.PracticeName else g.PracticeName end as PracticeName,
+				g.YearPracticeEstablished, g.NPI, i.EmailAddress, g.PracticeWebsite, g.PracticeDescription, g.PracticeLogo, g.PracticeMedicalDirector, 
+				g.PracticeSoftware, g.PracticeTIN, c.OfficeToAddressID, b.OfficeID, b.OfficeCode, 
+				case when a.OfficeName is not null then a.OfficeName else b.OfficeName end as OfficeName,
+				case
+					when h.ProviderID is NOT NULL then 1
+					else NULL
+				end as IsPrimaryOffice, 
+				a.ProviderOfficeRank, 
+				--d.AddressTypeCode, -- COMMENTED BY NANDITA
+				e.AddressID, e.AddressCode, 'Office' as AddressTypeCode, -- ADDED BY NANDITA
+				e.AddressLine1 + ISNULL(+' '+e.Suite,'') as AddressLine1, null AddressLine2, e.AddressLine3, e.AddressLine4,
+				j.City, j.State, j.PostalCode as ZipCode, j.County, k.NationName as Nation, e.Latitude, e.Longitude,
+				f.PhoneNumber as FullPhone,
+				z.PhoneNumber as FullFax,
+				c.IsDerived, b.HasBillingStaff, b.HasHandicapAccess, b.HasLabServicesOnSite, 
+				b.HasPharmacyOnSite, b.HasXrayOnSite, b.IsSurgeryCenter, b.HasSurgeryOnSite, 
+				b.AverageDailyPatientVolume, NULL as PhysicianCount, b.OfficeCoordinatorName, b.ParkingInformation, b.PaymentPolicy,
+				b.LegacyKey as LegacyKeyOffice, g.LegacyKey as LegacyKeyPractice
+			from #ProviderBatch pb 
+			inner join Base.ProviderToOffice as a with (nolock) on pb.ProviderID = a.ProviderID
+			inner join Base.Office as b with (nolock) on b.OfficeID = a.OfficeID
+			inner join Base.OfficeToAddress as c with (nolock) on b.OfficeID = c.OfficeID
+			--inner join Base.AddressType as d with (nolock)  on d.AddressTypeID = c.AddressTypeID
+			--left join Base.AddressType as d with (nolock)  on d.AddressTypeID = c.AddressTypeID--THIS IS TEMPORARY UNTIL THE ADDRESS_TYPE IS DONE... REMOVE THIS LATER -- COMMENTED BY NANDITA
+			--inner join Base.AddressType as d with (nolock) on d.AddressTypeID = c.AddressTypeID and d.AddressTypeCode in ('OFFICE','Practice','Hospital') -- ADDED BY NANDITA
+			inner join Base.Address as e with (nolock) on e.AddressID = c.AddressID	
+			--inner join Base.OfficeToPhone as f with (nolock) on f.OfficeID = b.OfficeID
+			left join 
+				(
+					--SERVICE NUMBERS
+					select x.PhoneNumber, x.OfficeID
+					from(
+						select b.PhoneNumber, a.OfficeID,ROW_NUMBER()OVER(PARTITION BY a.OfficeID ORDER BY a.PhoneRank, a.LastUpdateDate DESC, b.LastUpdateDate, a.PhoneId) AS SequenceId1
+						from Base.OfficeToPhone a
+						join Base.Phone b on (a.PhoneID = b.PhoneID)
+						where a.PhoneTypeID = (select PhoneTypeID from Base.PhoneType where PhoneTypeCode = 'Service')
+					)x
+					where SequenceId1 = 1
+				) f on (f.OfficeID = b.OfficeID)
+			left join 
+				(
+					--FAX NUMBERS
+					select x.PhoneNumber, x.OfficeID
+					from(
+						select b.PhoneNumber, a.OfficeID,ROW_NUMBER()OVER(PARTITION BY a.OfficeID ORDER BY a.PhoneRank, a.LastUpdateDate DESC, b.LastUpdateDate, a.PhoneId) AS SequenceId1
+						from Base.OfficeToPhone a
+						join Base.Phone b on (a.PhoneID = b.PhoneID)
+						where a.PhoneTypeID = (select PhoneTypeID from Base.PhoneType where PhoneTypeCode = 'Fax')
+					)x
+					where SequenceId1 = 1
+				) z	on (z.OfficeID = b.OfficeID)	
+			left join Base.CityStatePostalCode j with (nolock) on e.CityStatePostalCodeID = j.CityStatePostalCodeID
+			left join Base.Nation k on j.NationID = k.NationID
+			left join Base.Practice as g with (nolock) on g.PracticeID = b.PracticeID
+			--/*HACK*/left join ProfiseeAux.util.OfficePracticeSourceNames as hack on hack.ProviderID = pb.ProviderID and hack.OfficeID = b.OfficeID
+			left join 
+				(
+					select ProviderID, MIN(ProviderOfficeRank) as ProviderOfficeRank
+					from Base.ProviderToOffice
+					where ProviderOfficeRank is not null
+					group by ProviderID
+				)h on (a.ProviderID = h.ProviderID and a.ProviderOfficeRank = h.ProviderOfficeRank)
+			left join 
+				(
+					select PracticeID, EmailAddress, row_number() over(partition by PracticeID order by len(EmailAddress)) as EmailRank
+					from Base.PracticeEmail
+					where EmailAddress is not null
+				) i on i.PracticeID = b.PracticeID and i.EmailRank = 1
+			--where d.AddressTypeCode  = 'Service'--THIS IS TEMPORARY UNTIL THE ADDRESS_TYPE IS DONE... UNCOMMENT THIS LATER	
+			
+		--Update the PhysicianCount based on distinct providers at the Practice level
+			update a
+			set a.PhysicianCount = b.PhysicianCount
+			--select *
+			from #ProviderPracticeOffice a
+			join 
+				(
+					select PracticeID, COUNT(*) as PhysicianCount
+					from
+						(
+							select distinct ProviderID, PracticeID
+							from #ProviderPracticeOffice
+							where PracticeID is not null
+						)a	
+					group by PracticeID	
+				)b on (a.PracticeID = b.PracticeID)	
+					
+			create index temp on #ProviderPracticeOffice (ProviderToOfficeID)
+
+	/*
+		Flag record level actions for ActionCode
+			0 = No Change
+			1 = Insert
+			2 = Update
+	*/
+		--ActionCode Insert
+		update a
+		set a.ActionCode = 1
+		--select *
+		from #ProviderPracticeOffice a
+		left join Mid.ProviderPracticeOffice b on (a.ProviderID = b.ProviderID and a.OfficeID = b.OfficeID and isnull(a.FullPhone,'') = isnull(b.FullPhone,'') and isnull(a.FullFax,'') = isnull(b.FullFax,''))
+		where b.ProviderToOfficeID is null
+		
+		--ActionCode Update
+		update a
+		set a.ActionCode = 2
+		--select *
+		from #ProviderPracticeOffice a
+		join Mid.ProviderPracticeOffice b with (nolock) on (a.ProviderID = b.ProviderID and a.OfficeID = b.OfficeID and isnull(a.FullPhone,'') = isnull(b.FullPhone,'') and isnull(a.FullFax,'') = isnull(b.FullFax,''))
+		where BINARY_CHECKSUM(isnull(cast(a.AddressCode as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressCode as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AddressID as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressID as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AddressLine1 as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressLine1 as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AddressLine2 as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressLine2 as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AddressLine3 as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressLine3 as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AddressLine4 as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressLine4 as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AddressTypeCode as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AddressTypeCode as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.AverageDailyPatientVolume as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.AverageDailyPatientVolume as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.City as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.City as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.County as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.County as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.HasBillingStaff as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.HasBillingStaff as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.HasHandicapAccess as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.HasHandicapAccess as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.HasLabServicesOnSite as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.HasLabServicesOnSite as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.HasPharmacyOnSite as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.HasPharmacyOnSite as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.HasSurgeryOnSite as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.HasSurgeryOnSite as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.HasXrayOnSite as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.HasXrayOnSite as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.IsDerived as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.IsDerived as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.IsPrimaryOffice as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.IsPrimaryOffice as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.IsSurgeryCenter as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.IsSurgeryCenter as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.Latitude as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.Latitude as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.LegacyKeyOffice as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.LegacyKeyOffice as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.LegacyKeyPractice as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.LegacyKeyPractice as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.Longitude as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.Longitude as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.Nation as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.Nation as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.OfficeCode as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.OfficeCode as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.OfficeCoordinatorName as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.OfficeCoordinatorName as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.OfficeID as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.OfficeID as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.OfficeName as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.OfficeName as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.OfficeToAddressID as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.OfficeToAddressID as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.ParkingInformation as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ParkingInformation as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PaymentPolicy as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PaymentPolicy as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PhysicianCount as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PhysicianCount as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeCode as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeCode as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeDescription as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeDescription as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeEmail as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeEmail as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeID as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeID as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeLogo as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeLogo as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeMedicalDirector as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeMedicalDirector as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeName as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeName as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeNPI as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeNPI as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeSoftware as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeSoftware as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeTIN as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeTIN as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.PracticeWebsite as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.PracticeWebsite as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.ProviderID as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ProviderID as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.ProviderOfficeRank as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ProviderOfficeRank as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.State as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.State as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.YearPracticeEstablished as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.YearPracticeEstablished as varchar(max)),''))
+		 or BINARY_CHECKSUM(isnull(cast(a.ZipCode as varchar(max)),'')) <> BINARY_CHECKSUM(isnull(cast(b.ZipCode as varchar(max)),''))
+
+		;WITH cte_Dups AS (
+			SELECT	*,ROW_NUMBER()OVER(PARTITION BY ProviderId, OfficeId ORDER BY ProviderToOfficeId) AS SequenceId
+			FROM	#ProviderPracticeOffice
+		)
+		DELETE cte_Dups WHERE SequenceId > 1
+
+		insert into Mid.ProviderPracticeOffice (AddressCode,AddressID,AddressLine1,AddressLine2,AddressLine3,AddressLine4,AddressTypeCode,AverageDailyPatientVolume,City,County,FullFax,FullPhone,HasBillingStaff,HasHandicapAccess,HasLabServicesOnSite,HasPharmacyOnSite,HasSurgeryOnSite,HasXrayOnSite,IsDerived,IsPrimaryOffice,IsSurgeryCenter,Latitude,LegacyKeyOffice,LegacyKeyPractice,Longitude,Nation,OfficeCode,OfficeCoordinatorName,OfficeID,OfficeName,OfficeToAddressID,ParkingInformation,PaymentPolicy,PhysicianCount,PracticeCode,PracticeDescription,PracticeEmail,PracticeID,PracticeLogo,PracticeMedicalDirector,PracticeName,PracticeNPI,PracticeSoftware,PracticeTIN,PracticeWebsite,ProviderID,ProviderOfficeRank,ProviderToOfficeID,State,YearPracticeEstablished,ZipCode)
+		select	AddressCode,AddressID,AddressLine1,AddressLine2,AddressLine3,AddressLine4,AddressTypeCode,AverageDailyPatientVolume,City,County,FullFax,FullPhone,HasBillingStaff,HasHandicapAccess,HasLabServicesOnSite,HasPharmacyOnSite,HasSurgeryOnSite,HasXrayOnSite,IsDerived,IsPrimaryOffice,IsSurgeryCenter,Latitude,LegacyKeyOffice,LegacyKeyPractice,Longitude,Nation,OfficeCode,OfficeCoordinatorName,OfficeID,OfficeName,OfficeToAddressID,ParkingInformation,PaymentPolicy,PhysicianCount,PracticeCode,PracticeDescription,PracticeEmail,PracticeID,PracticeLogo,PracticeMedicalDirector,PracticeName,PracticeNPI,PracticeSoftware,PracticeTIN,PracticeWebsite,ProviderID,ProviderOfficeRank,ProviderToOfficeID,State,YearPracticeEstablished,ZipCode 
+		from	#ProviderPracticeOffice 
+		where	ActionCode = 1
+
+		update a
+		set a.AddressCode = b.AddressCode,
+		a.AddressID = b.AddressID,
+		a.AddressLine1 = b.AddressLine1,
+		a.AddressLine2 = b.AddressLine2,
+		a.AddressLine3 = b.AddressLine3,
+		a.AddressLine4 = b.AddressLine4,
+		a.AddressTypeCode = b.AddressTypeCode,
+		a.AverageDailyPatientVolume = b.AverageDailyPatientVolume,
+		a.City = b.City,
+		a.County = b.County,
+		a.HasBillingStaff = b.HasBillingStaff,
+		a.HasHandicapAccess = b.HasHandicapAccess,
+		a.HasLabServicesOnSite = b.HasLabServicesOnSite,
+		a.HasPharmacyOnSite = b.HasPharmacyOnSite,
+		a.HasSurgeryOnSite = b.HasSurgeryOnSite,
+		a.HasXrayOnSite = b.HasXrayOnSite,
+		a.IsDerived = b.IsDerived,
+		a.IsPrimaryOffice = b.IsPrimaryOffice,
+		a.IsSurgeryCenter = b.IsSurgeryCenter,
+		a.Latitude = b.Latitude,
+		a.LegacyKeyOffice = b.LegacyKeyOffice,
+		a.LegacyKeyPractice = b.LegacyKeyPractice,
+		a.Longitude = b.Longitude,
+		a.Nation = b.Nation,
+		a.OfficeCode = b.OfficeCode,
+		a.OfficeCoordinatorName = b.OfficeCoordinatorName,
+		a.OfficeID = b.OfficeID,
+		a.OfficeName = b.OfficeName,
+		a.OfficeToAddressID = b.OfficeToAddressID,
+		a.ParkingInformation = b.ParkingInformation,
+		a.PaymentPolicy = b.PaymentPolicy,
+		a.PhysicianCount = b.PhysicianCount,
+		a.PracticeCode = b.PracticeCode,
+		a.PracticeDescription = b.PracticeDescription,
+		a.PracticeEmail = b.PracticeEmail,
+		a.PracticeID = b.PracticeID,
+		a.PracticeLogo = b.PracticeLogo,
+		a.PracticeMedicalDirector = b.PracticeMedicalDirector,
+		a.PracticeName = b.PracticeName,
+		a.PracticeNPI = b.PracticeNPI,
+		a.PracticeSoftware = b.PracticeSoftware,
+		a.PracticeTIN = b.PracticeTIN,
+		a.PracticeWebsite = b.PracticeWebsite,
+		a.ProviderID = b.ProviderID,
+		a.ProviderOfficeRank = b.ProviderOfficeRank,
+		a.State = b.State,
+		a.YearPracticeEstablished = b.YearPracticeEstablished,
+		a.ZipCode = b.ZipCode
+		--select *
+		from Mid.ProviderPracticeOffice a with (nolock)
+		join #ProviderPracticeOffice b on (a.ProviderID = b.ProviderID and a.OfficeID = b.OfficeID and isnull(a.FullPhone,'') = isnull(b.FullPhone,'') and isnull(a.FullFax,'') = isnull(b.FullFax,''))
+		where b.ActionCode = 2
+
+		--ActionCode = N (Deletes)
+			delete a
+			--select *
+			from Mid.ProviderPracticeOffice a with (nolock)
+			inner join #ProviderBatch pb on a.ProviderID = pb.ProviderID
+			left join #ProviderPracticeOffice b on (a.ProviderID = b.ProviderID and a.OfficeID = b.OfficeID and isnull(a.FullPhone,'') = isnull(b.FullPhone,'') and isnull(a.FullFax,'') = isnull(b.FullFax,''))
+			where b.ProviderToOfficeID is null
+	
+				
+		UPDATE		A 
+		SET			OfficeName = [dbo].[fnuRemoveSpecialHexadecimalCharacters](OfficeName)
+		FROM		Mid.ProviderPracticeOffice a
+		WHERE		CHARINDEX(CHAR(0x0000),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0001),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0002),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0003),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0004),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0005),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0006),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0007),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0008),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x000B),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x000C),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x000E),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x000F),a.OfficeName) <> 0 
+					OR CHARINDEX(CHAR(0x0010),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0011),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0012),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0013),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0014),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0015),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0016),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0017),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0018),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x0019),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x001A),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x001B),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x001C),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x001D),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x001E),a.OfficeName) <> 0
+					OR CHARINDEX(CHAR(0x001F),a.OfficeName) <> 0
+
+	/*
+		DELTAS FOR SOLR HERE
+	*/		
+		
+		
+end try
+begin catch
+    set @ErrorMessage = 'Error in procedure Mid.spuProviderPracticeOfficeRefresh, line ' + convert(varchar(20), error_line()) + ': ' + error_message()
+    raiserror(@ErrorMessage, 18, 1)
+end catch
+GO

--- a/migration_original/ODS1Stage/tables/Mid/ProviderPracticeOffice/spu_translated_ProviderPracticeOffice.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderPracticeOffice/spu_translated_ProviderPracticeOffice.sql
@@ -30,7 +30,6 @@ DECLARE
 delta_select_statement STRING; -- CTE and Select statement for delta
 select_statement STRING; -- CTE and Select statement for the Merge
 update_statement STRING; -- Main Update statement for the Merge
-update_statement_hex STRING; -- Update statement to replace hex chars
 insert_statement STRING; -- Insert statement for the Merge
 merge_statement STRING; -- Merge statement to final table
 status STRING; -- Status monitoring

--- a/migration_original/ODS1Stage/tables/Mid/ProviderPracticeOffice/spu_translated_ProviderPracticeOffice.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderPracticeOffice/spu_translated_ProviderPracticeOffice.sql
@@ -1,0 +1,524 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.MID.SP_LOAD_PROVIDERPRACTICEOFFICE(IsProviderDeltaProcessing BOOLEAN)
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+
+-- base.officetoaddress
+-- base.practice
+-- base.officetophone
+-- mid.providerpracticeoffice
+-- base.provider
+-- base.phone
+-- base.nation
+-- base.address
+-- base.phonetype
+-- base.practiceemail
+-- base.office
+-- base.providertooffice
+-- raw.providerdeltaprocessing
+-- base.citystate
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+delta_select_statement STRING; -- CTE and Select statement for delta
+select_statement STRING; -- CTE and Select statement for the Merge
+update_statement STRING; -- Main Update statement for the Merge
+update_statement_hex STRING; -- Update statement to replace hex chars
+insert_statement STRING; -- Insert statement for the Merge
+merge_statement STRING; -- Merge statement to final table
+status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    IF (IsProviderDeltaProcessing) THEN
+       EXECUTE IMMEDIATE $$ TRUNCATE TABLE Mid.ProviderPracticeOffice $$;
+       delta_select_statement :=  $$        
+                            WITH CTE_ProviderBatch AS (
+                            SELECT pdp.ProviderID
+                            FROM Raw.ProviderDeltaProcessing as pdp), 
+                            $$;
+    ELSE
+       EXECUTE IMMEDIATE $$ DELETE FROM Mid.ProviderPracticeOffice ppo 
+                              USING raw.ProviderDeltaProcessing pdp
+                              WHERE pdp.ProviderID = ppo.ProviderID 
+                         $$;
+            
+       delta_select_statement := $$
+                               WITH CTE_ProviderBatch AS (
+                                    SELECT p.ProviderID
+                                    FROM Base.Provider as p
+                                    ORDER BY p.ProviderID),
+                               $$;
+    END IF;
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+select_statement := delta_select_statement || 
+            $$
+            CTE_ServiceNumbers AS (
+                SELECT o.PhoneNumber, pto.OfficeID, ROW_NUMBER() OVER(PARTITION BY pto.OfficeID ORDER BY pto.PhoneRank, pto.LastUpdateDate DESC, 
+                       o.LastUpdateDate, pto.PhoneId) AS SequenceId1   
+                FROM Base.OfficeToPhone pto
+                JOIN Base.Phone o ON (pto.PhoneID = o.PhoneID)
+                WHERE pto.PhoneTypeID = (SELECT PhoneTypeID FROM Base.PhoneType WHERE PhoneTypeCode = 'Service') 
+            ),
+            
+            CTE_FaxNumbers AS (
+                SELECT o.PhoneNumber, pto.OfficeID, ROW_NUMBER() OVER(PARTITION BY pto.OfficeID ORDER BY pto.PhoneRank, pto.LastUpdateDate DESC,                      o.LastUpdateDate, pto.PhoneId) AS SequenceId1
+                FROM Base.OfficeToPhone pto
+                JOIN Base.Phone o ON (pto.PhoneID = o.PhoneID)
+                WHERE pto.PhoneTypeID = (SELECT PhoneTypeID FROM Base.PhoneType WHERE PhoneTypeCode = 'Fax') 
+            ),
+            
+            CTE_ProviderOfficeRank AS (
+                SELECT ProviderID, MIN(ProviderOfficeRank) AS ProviderOfficeRank
+                FROM Base.ProviderToOffice
+                WHERE ProviderOfficeRank IS NOT NULL
+                GROUP BY ProviderID
+            ),
+            
+            CTE_PracticeEmails AS (
+                SELECT PracticeID, EmailAddress, ROW_NUMBER() OVER (PARTITION BY PracticeID ORDER BY LEN(EmailAddress)) AS EmailRank
+                FROM Base.PracticeEmail
+                WHERE EmailAddress IS NOT NULL
+            ),
+            
+            CTE_ProviderPracticeOffice AS (
+                SELECT DISTINCT 
+                    pto.ProviderToOfficeID, 
+                    pto.ProviderID,  
+                    p.PracticeID, 
+                    p.PracticeCode, 
+                    CASE 
+                        WHEN pto.PracticeName IS NOT NULL THEN pto.PracticeName 
+                        ELSE p.PracticeName 
+                    END AS PracticeName,
+                    p.YearPracticeEstablished, 
+                    p.NPI AS PracticeNPI, 
+                    cte_pe.EmailAddress AS PracticeEmail,
+                    p.PracticeWebsite, 
+                    p.PracticeDescription, 
+                    p.PracticeLogo, 
+                    p.PracticeMedicalDirector, 
+                    p.PracticeSoftware, 
+                    p.PracticeTIN, 
+                    ota.OfficeToAddressID, 
+                    o.OfficeID, 
+                    o.OfficeCode, 
+                    CASE 
+                        WHEN pto.OfficeName IS NOT NULL THEN pto.OfficeName 
+                        ELSE o.OfficeName 
+                    END AS OfficeName, 
+                    CASE
+                        WHEN cte_por.ProviderID IS NOT NULL THEN 1
+                        ELSE NULL 
+                    END AS IsPrimaryOffice, 
+                    pto.ProviderOfficeRank, 
+                    a.AddressID, 
+                    a.AddressCode, 
+                    'Office' AS AddressTypeCode, 
+                    a.AddressLine1 AS AddressLine1, 
+                    NULL AS AddressLine2, 
+                    a.AddressLine3, 
+                    a.AddressLine4,
+                    cspc.City, 
+                    cspc.State, 
+                    cspc.PostalCode AS ZipCode, 
+                    cspc.County, 
+                    n.NationName AS Nation, 
+                    a.Latitude, 
+                    a.Longitude,
+                    cte_sn.PhoneNumber AS FullPhone,
+                    cte_fn.PhoneNumber AS FullFax,
+                    ota.IsDerived, 
+                    o.HasBillingStaff,
+                    o.HasHandicapAccess, 
+                    o.HasLabServicesOnSite, 
+                    o.HasPharmacyOnSite, 
+                    o.HasXrayOnSite, 
+                    o.IsSurgeryCenter, 
+                    o.HasSurgeryOnSite, 
+                    o.AverageDailyPatientVolume, 
+                    NULL AS PhysicianCount, 
+                    o.OfficeCoordinatorName, 
+                    o.ParkingInformation, 
+                    o.PaymentPolicy,
+                    o.LegacyKey AS LegacyKeyOffice, 
+                    p.LegacyKey AS LegacyKeyPractice,
+                    0 AS ActionCode
+                FROM CTE_ProviderBatch pb 
+                INNER JOIN Base.ProviderToOffice AS pto ON pb.ProviderID = pto.ProviderID
+                INNER JOIN Base.Office AS o ON o.OfficeID = pto.OfficeID
+                INNER JOIN Base.OfficeToAddress AS ota ON o.OfficeID = ota.OfficeID
+                INNER JOIN Base.Address AS a ON a.AddressID = ota.AddressID	
+                LEFT JOIN CTE_ServiceNumbers AS cte_sn ON cte_sn.OfficeID = o.OfficeID AND cte_sn.SequenceId1 = 1
+                LEFT JOIN CTE_FaxNumbers AS cte_fn ON cte_fn.OfficeID = o.OfficeID AND cte_fn.SequenceId1 = 1
+                LEFT JOIN Base.CityStatePostalCode AS cspc ON a.CityStatePostalCodeID = cspc.CityStatePostalCodeID
+                LEFT JOIN Base.Nation AS n ON cspc.NationID = n.NationID
+                LEFT JOIN Base.Practice AS p ON o.PracticeID = p.PracticeID
+                LEFT JOIN CTE_ProviderOfficeRank AS cte_por ON pto.ProviderID = cte_por.ProviderID AND pto.ProviderOfficeRank = cte_por.ProviderOfficeRank
+                LEFT JOIN CTE_PracticeEmails cte_pe ON cte_pe.PracticeID = o.PracticeID AND cte_pe.EmailRank = 1
+            ),
+            
+            -- Insert Action
+            CTE_Action_1 AS (
+                    SELECT 
+                        cte.ProviderID,
+                        cte.OfficeID,
+                        cte.FullPhone,
+                        cte.FullFax,
+                        1 AS ActionCode
+                    FROM CTE_ProviderPracticeOffice AS cte
+                    LEFT JOIN Mid.ProviderPracticeOffice AS mid 
+                        ON (cte.ProviderID = mid.ProviderID AND cte.OfficeID = mid.OfficeID
+                        AND IFNULL(cte.FullPhone, '') = IFNULL(mid.FullPhone, '')
+                        AND IFNULL(cte.FullFax, '') = IFNULL(mid.FullFax, ''))
+                    WHERE mid.ProviderToOfficeID IS NULL
+            ),
+            
+            -- Update Action
+            CTE_Action_2 AS (
+                    SELECT 
+                        cte.ProviderID,
+                        cte.OfficeID,
+                        cte.FullPhone,
+                        cte.FullFax,
+                        2 AS ActionCode
+                    FROM CTE_ProviderPracticeOffice AS cte
+                    INNER JOIN Mid.ProviderPracticeOffice AS mid 
+                        ON (cte.ProviderID = mid.ProviderID AND cte.OfficeID = mid.OfficeID
+                        AND IFNULL(cte.FullPhone, '') = IFNULL(mid.FullPhone, '')
+                        AND IFNULL(cte.FullFax, '') = IFNULL(mid.FullFax, ''))
+                    WHERE 
+                        MD5(IFNULL(cte.AddressCode::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressCode::VARCHAR,'''')) OR 
+                        MD5(IFNULL(cte.AddressID::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressID::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.AddressLine1::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressLine1::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.AddressLine2::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressLine2::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.AddressLine3::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressLine3::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.AddressLine4::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressLine4::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.AddressTypeCode::VARCHAR,'''')) <> MD5(IFNULL(mid.AddressTypeCode::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.AverageDailyPatientVolume::VARCHAR,'''')) <> MD5(IFNULL(mid.AverageDailyPatientVolume::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.City::VARCHAR,'''')) <> MD5(IFNULL(mid.City::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.County::VARCHAR,'''')) <> MD5(IFNULL(mid.County::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.FullFax::VARCHAR,'''')) <> MD5(IFNULL(mid.FullFax::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.FullPhone::VARCHAR,'''')) <> MD5(IFNULL(mid.FullPhone::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.HasBillingStaff::VARCHAR,'''')) <> MD5(IFNULL(mid.HasBillingStaff::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.HasHandicapAccess::VARCHAR,'''')) <> MD5(IFNULL(mid.HasHandicapAccess::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.HasLabServicesOnSite::VARCHAR,'''')) <> MD5(IFNULL(mid.HasLabServicesOnSite::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.HasPharmacyOnSite::VARCHAR,'''')) <> MD5(IFNULL(mid.HasPharmacyOnSite::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.HasSurgeryOnSite::VARCHAR,'''')) <> MD5(IFNULL(mid.HasSurgeryOnSite::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.HasXrayOnSite::VARCHAR,'''')) <> MD5(IFNULL(mid.HasXrayOnSite::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.IsDerived::VARCHAR,'''')) <> MD5(IFNULL(mid.IsDerived::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.IsPrimaryOffice::VARCHAR,'''')) <> MD5(IFNULL(mid.IsPrimaryOffice::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.IsSurgeryCenter::VARCHAR,'''')) <> MD5(IFNULL(mid.IsSurgeryCenter::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.Latitude::VARCHAR,'''')) <> MD5(IFNULL(mid.Latitude::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.LegacyKeyOffice::VARCHAR,'''')) <> MD5(IFNULL(mid.LegacyKeyOffice::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.LegacyKeyPractice::VARCHAR,'''')) <> MD5(IFNULL(mid.LegacyKeyPractice::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.Longitude::VARCHAR,'''')) <> MD5(IFNULL(mid.Longitude::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.Nation::VARCHAR,'''')) <> MD5(IFNULL(mid.Nation::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.OfficeCode::VARCHAR,'''')) <> MD5(IFNULL(mid.OfficeCode::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.OfficeCoordinatorName::VARCHAR,'''')) <> MD5(IFNULL(mid.OfficeCoordinatorName::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.OfficeID::VARCHAR,'''')) <> MD5(IFNULL(mid.OfficeID::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.OfficeName::VARCHAR,'''')) <> MD5(IFNULL(mid.OfficeName::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.OfficeToAddressID::VARCHAR,'''')) <> MD5(IFNULL(mid.OfficeToAddressID::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.ParkingInformation::VARCHAR,'''')) <> MD5(IFNULL(mid.ParkingInformation::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PaymentPolicy::VARCHAR,'''')) <> MD5(IFNULL(mid.PaymentPolicy::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PhysicianCount::VARCHAR,'''')) <> MD5(IFNULL(mid.PhysicianCount::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeCode::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeCode::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeDescription::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeDescription::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeEmail::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeEmail::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeID::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeID::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeLogo::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeLogo::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeMedicalDirector::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeMedicalDirector::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeName::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeName::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeNPI::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeNPI::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeSoftware::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeSoftware::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeTIN::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeTIN::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.PracticeWebsite::VARCHAR,'''')) <> MD5(IFNULL(mid.PracticeWebsite::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.ProviderID::VARCHAR,'''')) <> MD5(IFNULL(mid.ProviderID::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.ProviderOfficeRank::VARCHAR,'''')) <> MD5(IFNULL(mid.ProviderOfficeRank::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.ProviderToOfficeID::VARCHAR,'''')) <> MD5(IFNULL(mid.ProviderToOfficeID::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.State::VARCHAR,'''')) <> MD5(IFNULL(mid.State::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.YearPracticeEstablished::VARCHAR,'''')) <> MD5(IFNULL(mid.YearPracticeEstablished::VARCHAR,'''')) OR
+                        MD5(IFNULL(cte.ZipCode::VARCHAR,'''')) <> MD5(IFNULL(mid.ZipCode::VARCHAR,''''))
+            )
+            
+            SELECT DISTINCT
+                A0.AddressCode,
+                A0.AddressID,
+                A0.AddressLine1,
+                A0.AddressLine2,
+                A0.AddressLine3,
+                A0.AddressLine4,
+                A0.AddressTypeCode,
+                A0.AverageDailyPatientVolume,
+                A0.City,
+                A0.County,
+                A0.FullFax,
+                A0.FullPhone,
+                A0.HasBillingStaff,
+                A0.HasHandicapAccess,
+                A0.HasLabServicesOnSite,
+                A0.HasPharmacyOnSite,
+                A0.HasSurgeryOnSite,
+                A0.HasXrayOnSite,
+                A0.IsDerived,
+                A0.IsPrimaryOffice,
+                A0.IsSurgeryCenter,
+                A0.Latitude,
+                A0.LegacyKeyOffice,
+                A0.LegacyKeyPractice,
+                A0.Longitude,
+                A0.Nation,
+                A0.OfficeCode,
+                A0.OfficeCoordinatorName,
+                A0.OfficeID,
+                A0.OfficeName,
+                A0.OfficeToAddressID,
+                A0.ParkingInformation,
+                A0.PaymentPolicy,
+                A0.PhysicianCount,
+                A0.PracticeCode,
+                A0.PracticeDescription,
+                A0.PracticeEmail,
+                A0.PracticeID,
+                A0.PracticeLogo,
+                A0.PracticeMedicalDirector,
+                A0.PracticeName,
+                A0.PracticeNPI,
+                A0.PracticeSoftware,
+                A0.PracticeTIN,
+                A0.PracticeWebsite,
+                A0.ProviderID,
+                A0.ProviderOfficeRank,
+                A0.ProviderToOfficeID,
+                A0.State,
+                A0.YearPracticeEstablished,
+                A0.ZipCode,
+                IFNULL(A1.ActionCode,IFNULL(A2.ActionCode, A0.ActionCode)) AS ActionCode  
+            FROM CTE_ProviderPracticeOffice AS A0
+            LEFT JOIN CTE_Action_1 AS A1 ON A0.ProviderID = A1.ProviderID AND A0.OfficeID = A1.OfficeID
+            LEFT JOIN CTE_Action_2 AS A2 ON A0.ProviderID = A2.ProviderID AND A0.OfficeID = A2.OfficeID
+            WHERE IFNULL(A1.ActionCode,IFNULL(A2.ActionCode, A0.ActionCode)) <> 0
+            $$;
+                        
+
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------
+
+update_statement := $$
+                     UPDATE SET 
+                        target.AddressCode = source.AddressCode,
+                        target.AddressID = source.AddressID,
+                        target.AddressLine1 = source.AddressLine1,
+                        target.AddressLine2 = source.AddressLine2,
+                        target.AddressLine3 = source.AddressLine3,
+                        target.AddressLine4 = source.AddressLine4,
+                        target.AddressTypeCode = source.AddressTypeCode,
+                        target.AverageDailyPatientVolume = source.AverageDailyPatientVolume,
+                        target.City = CASE 
+                                        WHEN source.City || ', ' || source.State LIKE '%,,%' THEN LEFT(source.City, LENGTH(source.City) - 1)
+                                        ELSE source.City
+                                      END,
+                        target.County = source.County,
+                        target.FullFax = source.FullFax,
+                        target.FullPhone = source.FullPhone,
+                        target.HasBillingStaff = source.HasBillingStaff,
+                        target.HasHandicapAccess = source.HasHandicapAccess,
+                        target.HasLabServicesOnSite = source.HasLabServicesOnSite,
+                        target.HasPharmacyOnSite = source.HasPharmacyOnSite,
+                        target.HasSurgeryOnSite = source.HasSurgeryOnSite,
+                        target.HasXrayOnSite = source.HasXrayOnSite,
+                        target.IsDerived = source.IsDerived,
+                        target.IsPrimaryOffice = source.IsPrimaryOffice,
+                        target.IsSurgeryCenter = source.IsSurgeryCenter,
+                        target.Latitude = source.Latitude,
+                        target.LegacyKeyOffice = source.LegacyKeyOffice,
+                        target.LegacyKeyPractice = source.LegacyKeyPractice,
+                        target.Longitude = source.Longitude,
+                        target.Nation = source.Nation,
+                        target.OfficeCode = source.OfficeCode,
+                        target.OfficeCoordinatorName = source.OfficeCoordinatorName,
+                        target.OfficeID = source.OfficeID,
+                        target.OfficeName = Mid.FNUREMOVESPECIALHEXADECIMALCHARACTERS(source.OfficeName),
+                        target.OfficeToAddressID = source.OfficeToAddressID,
+                        target.ParkingInformation = source.ParkingInformation,
+                        target.PaymentPolicy = source.PaymentPolicy,
+                        target.PhysicianCount = source.PhysicianCount,
+                        target.PracticeCode = source.PracticeCode,
+                        target.PracticeDescription = source.PracticeDescription,
+                        target.PracticeEmail = source.PracticeEmail,
+                        target.PracticeID = source.PracticeID,
+                        target.PracticeLogo = source.PracticeLogo,
+                        target.PracticeMedicalDirector = source.PracticeMedicalDirector,
+                        target.PracticeName = source.PracticeName,
+                        target.PracticeNPI = source.PracticeNPI,
+                        target.PracticeSoftware = source.PracticeSoftware,
+                        target.PracticeTIN = source.PracticeTIN,
+                        target.PracticeWebsite = source.PracticeWebsite,
+                        target.ProviderID = source.ProviderID,
+                        target.ProviderOfficeRank = source.ProviderOfficeRank,
+                        target.ProviderToOfficeID = source.ProviderToOfficeID,
+                        target.State = source.State,
+                        target.YearPracticeEstablished = source.YearPracticeEstablished,
+                        target.ZipCode = source.ZipCode
+                      $$;
+
+
+--- Insert Statement
+insert_statement :=   $$
+                      INSERT  (
+                                AddressCode,
+                                AddressID,
+                                AddressLine1,
+                                AddressLine2,
+                                AddressLine3,
+                                AddressLine4,
+                                AddressTypeCode,
+                                AverageDailyPatientVolume,
+                                City,
+                                County,
+                                FullFax,
+                                FullPhone,
+                                HasBillingStaff,
+                                HasHandicapAccess,
+                                HasLabServicesOnSite,
+                                HasPharmacyOnSite,
+                                HasSurgeryOnSite,
+                                HasXrayOnSite,
+                                IsDerived,
+                                IsPrimaryOffice,
+                                IsSurgeryCenter,
+                                Latitude,
+                                LegacyKeyOffice,
+                                LegacyKeyPractice,
+                                Longitude,
+                                Nation,
+                                OfficeCode,
+                                OfficeCoordinatorName,
+                                OfficeID,
+                                OfficeName,
+                                OfficeToAddressID,
+                                ParkingInformation,
+                                PaymentPolicy,
+                                PhysicianCount,
+                                PracticeCode,
+                                PracticeDescription,
+                                PracticeEmail,
+                                PracticeID,
+                                PracticeLogo,
+                                PracticeMedicalDirector,
+                                PracticeName,
+                                PracticeNPI,
+                                PracticeSoftware,
+                                PracticeTIN,
+                                PracticeWebsite,
+                                ProviderID,
+                                ProviderOfficeRank,
+                                ProviderToOfficeID,
+                                State,
+                                YearPracticeEstablished,
+                                ZipCode
+                               )
+                      VALUES  (
+                                source.AddressCode,
+                                source.AddressID,
+                                source.AddressLine1,
+                                source.AddressLine2,
+                                source.AddressLine3,
+                                source.AddressLine4,
+                                source.AddressTypeCode,
+                                source.AverageDailyPatientVolume,
+                                source.City,
+                                source.County,
+                                source.FullFax,
+                                source.FullPhone,
+                                source.HasBillingStaff,
+                                source.HasHandicapAccess,
+                                source.HasLabServicesOnSite,
+                                source.HasPharmacyOnSite,
+                                source.HasSurgeryOnSite,
+                                source.HasXrayOnSite,
+                                source.IsDerived,
+                                source.IsPrimaryOffice,
+                                source.IsSurgeryCenter,
+                                source.Latitude,
+                                source.LegacyKeyOffice,
+                                source.LegacyKeyPractice,
+                                source.Longitude,
+                                source.Nation,
+                                source.OfficeCode,
+                                source.OfficeCoordinatorName,
+                                source.OfficeID,
+                                source.OfficeName,
+                                source.OfficeToAddressID,
+                                source.ParkingInformation,
+                                source.PaymentPolicy,
+                                source.PhysicianCount,
+                                source.PracticeCode,
+                                source.PracticeDescription,
+                                source.PracticeEmail,
+                                source.PracticeID,
+                                source.PracticeLogo,
+                                source.PracticeMedicalDirector,
+                                source.PracticeName,
+                                source.PracticeNPI,
+                                source.PracticeSoftware,
+                                source.PracticeTIN,
+                                source.PracticeWebsite,
+                                source.ProviderID,
+                                source.ProviderOfficeRank,
+                                source.ProviderToOfficeID,
+                                source.State,
+                                source.YearPracticeEstablished,
+                                source.ZipCode
+                               )
+                       $$;
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+merge_statement :=  $$
+                    MERGE INTO Mid.ProviderPracticeOffice as target USING ($$|| select_statement ||$$) as source 
+                    ON source.ProviderID = target.ProviderID
+                    WHEN MATCHED AND source.ActionCode = 2 THEN $$|| update_statement ||$$
+                    WHEN NOT MATCHED AND source.ActionCode = 1 THEN $$ || insert_statement;
+
+                
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE merge_statement;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+END;


### PR DESCRIPTION
The hacky update in spuMidProviderEntityRefresh was converted to a CASE-WHEN (lines 334-337). The last update in spuProviderPracticeOfficeRefresh was combined to the main update in the merge (line 358) by calling the dbo function (now in Mid schema) there instead. There are no PKs so programmatic validation is tricky, but I checked 10 rows manually and they matched.

A few things to note: 
1. This proc reminded me of the precision of the longitude/latitude columns which will have to be taken into consideration later on when modifying the table column types.
2. Window functions appear to be dead. We could save compute later on by confirming and getting rid of them. 
3. The truncate logic seems unnecessary, but I did not want to change the logic of the original code. 