### PR TITLE
base.citystatepostalcode

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/CityStatePostalCode/spu_original_CityStatePostalCode.sql
+++ b/migration_original/ODS1Stage/tables/Base/CityStatePostalCode/spu_original_CityStatePostalCode.sql
@@ -1,0 +1,140 @@
+-- etl.spumergecitystatepostalcode (line 61, run inside etl.spumergeofficeaddress)
+
+IF OBJECT_ID('tempdb..#SwimLane') IS NOT NULL DROP TABLE #SwimLane
+	SELECT	DISTINCT y.City, y.State, y.PostalCode
+	INTO	#swimlane
+	FROM(
+		SELECT	w.CREATE_DATE, w.ReltioEntityID, w.OfficeCode, w.OfficeID, w.OfficeJSON
+		FROM(
+			SELECT		p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.OFFICE_CODE as OfficeCode, p.OfficeID, 
+						json_query(p.PAYLOAD, '$.EntityJSONString.Address')  as OfficeJSON
+			FROM		raw.OfficeProfileProcessingDeDup as d with (nolock)
+			INNER JOIN	raw.OfficeProfileProcessing as p with (nolock) on p.rawOfficeProfileID = d.rawOfficeProfileID
+			WHERE		p.PAYLOAD is not null
+		) AS w
+		WHERE	w.OfficeJSON IS NOT NULL
+	) AS x
+	CROSS APPLY(
+		SELECT	*
+		FROM	openjson(x.OfficeJSON) with 
+                (AddressTypeCode varchar(50) '$.AddressTypeCode', 
+				OfficeName varchar(100) '$."OfficeName"',
+				AddressRank int '$.Rank',
+				AddressLine1 varchar(50) '$.AddressLine1',
+				AddressLine2 varchar(50) '$.AddressLine2',
+				Suite varchar(50) '$.Suite',
+				City varchar(50) '$.City',
+				State varchar(50) '$.StateProvince',
+				PostalCode varchar(50) '$.PostalCode',
+				Latitude varchar(50) '$.Latitude',
+				Longitude varchar(50) '$.Longitude',
+				TimeZone varchar(50) '$.TimeZone',
+				DoSuppress bit '$.DoSuppress', 
+				IsDerived bit '$.IsDerived', 
+                LastUpdateDate datetime '$.LastUpdateDate', 
+				OfficeCode varchar(50) '$.OfficeCode', 
+                SourceCode varchar(25) '$.SourceCode')
+	) AS y
+	WHERE	isnull(y.DoSuppress, 0) = 0 
+			AND nullif(y.City,'') IS NOT NULL 
+			AND nullif(y.State,'') IS NOT NULL 
+			AND nullif(y.PostalCode,'') IS NOT NULL
+			AND LEN(UPPER(LTRIM(RTRIM(AddressLine1))) + ISNULL(UPPER(LTRIM(RTRIM(AddressLine2))),'') + ISNULL(UPPER(LTRIM(RTRIM(Suite))),'')) > 0
+
+	UPDATE	#swimlane
+	SET		City = LEFT(LTRIM(RTRIM(CITY)),LEN(CITY)-1)
+	WHERE	LTRIM(RTRIM(City)) LIKE '%,'
+	
+	UPDATE		T
+	SET			State = S.State
+	FROM		#swimlane T
+	INNER JOIN	ODS1Stage.Base.State S
+				ON LTRIM(RTRIM(S.StateName)) = LTRIM(RTRIM(T.State))
+
+    INSERT INTO	ODS1Stage.Base.CityStatePostalCode (CityStatePostalCodeID, City, State, PostalCode, LastUpdateDate)
+    SELECT		newid(), s.City, s.State, s.PostalCode, GETDATE()
+    FROM		#swimlane as s
+	INNER JOIN	ODS1Stage.Base.[State] dST WITH(NOLOCK)
+				ON dST.[State] = s.[State]
+	LEFT JOIN	ODS1Stage.Base.CityStatePostalCode dCSP WITH(NOLOCK)
+				ON dCSP.City = S.City
+				AND dCSP.[State] = s.[State]
+				AND dCSP.PostalCode = s.PostalCode
+	WHERE		dCSP.CityStatePostalCodeID IS NULL
+	
+    INSERT INTO	ODS1Stage.Base.CityStatePostalCode (CityStatePostalCodeID, City, State, PostalCode, LastUpdateDate)
+    SELECT		newid(), s.City, s.State, s.PostalCode, GETDATE()
+    FROM		#swimlane as s
+	INNER JOIN	ODS1Stage.Base.[State] dST WITH(NOLOCK)
+				ON dST.[State] = dST.[StateName]
+	LEFT JOIN	ODS1Stage.Base.CityStatePostalCode dCSP WITH(NOLOCK)
+				ON dCSP.City = S.City
+				AND dCSP.[State] = dST.[StateName]
+				AND dCSP.PostalCode = s.PostalCode
+	WHERE		dCSP.CityStatePostalCodeID IS NULL
+
+
+-- etl.spumergefacilityaddress (line 72)
+
+if object_id('tempdb..#swimlane') is not null drop table #swimlane
+        select	distinct f.FacilityID
+				,y.AddressLine1
+				,y.City
+				,y.State
+				,y.Country
+				,y.PostalCode
+				,y.Latitude
+				,y.Longitude
+				,y.SourceCode
+				,x.FacilityCode
+				,row_number() over(partition by x.FacilityID order by x.CREATE_DATE desc) as RowRank
+        into #swimlane
+        from
+        (
+            select w.* 
+            from
+            (
+                select p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.Facility_CODE as FacilityCode, p.FacilityID, 
+                    json_query(p.PAYLOAD, '$.EntityJSONString.Address')  as FacilityJSON
+                from raw.FacilityProfileProcessingDeDup as d with (nolock)
+                inner join raw.FacilityProfileProcessing as p with (nolock) on p.rawFacilityProfileID = d.rawFacilityProfileID
+				--from(select * from Snowflake.raw.FacilityProfileComplete_20201026_132026_483 ) p
+                where p.PAYLOAD is not null
+            ) as w
+            where w.FacilityJSON is not null
+        ) as x
+        cross apply 
+        (
+            select *
+            from openjson(x.FacilityJSON) with (
+			    AddressLine1 varchar(150) '$.AddressLine1'
+			    ,City varchar(150)  '$.City'
+				,State varchar(50)  '$.StateProvince'
+				,Country varchar(50)  '$.Country'
+				,PostalCode varchar(50)  '$.PostalCode'
+				,Latitude varchar(50)  '$.Latitude'
+				,Longitude varchar(50)  '$.Longitude'
+                ,LastUpdateDate datetime2 '$.LastUpdateDate'
+			    ,SourceCode varchar(80) '$.SourceCode'
+		    )
+        ) as y
+		join ODS1Stage.Base.Facility f on x.FacilityCode=f.FacilityCode
+		where nullif(y.City,'') is not null 
+			and nullif(y.State,'') is not null 
+			and nullif(y.PostalCode,'') is not null
+    
+		IF OBJECT_ID('tempdb..#TempCityStatePostal') IS NOT NULL DROP TABLE #TempCityStatePostal
+		SELECT	DISTINCT City,State,PostalCode, Latitude, Longitude
+		INTO	#TempCityStatePostal
+		FROM	#swimlane
+
+		INSERT INTO ODS1Stage.Base.CityStatePostalCode(CityStatePostalCodeId, City, State, PostalCode, CentroidLatitude, CentroidLongitude, NationId, LastUpdateDate)
+		SELECT		NewId(), S.City, S.State, S.PostalCode, S.Latitude, S.Longitude, '00415355-0000-0000-0000-000000000000', getdate()
+		FROM(
+			SELECT DISTINCT S.City, S.State, S.PostalCode, S.Latitude, S.Longitude
+			FROM #TempCityStatePostal S
+				LEFT JOIN ODS1Stage.Base.CityStatePostalCode T ON T.City = S.City AND T.State = S.State AND T.PostalCode = S.PostalCode
+			WHERE T.CityStatePostalCodeId IS NULL
+		) S
+
+

--- a/migration_original/ODS1Stage/tables/Base/CityStatePostalCode/spu_translated_CityStatePostalCode.sql
+++ b/migration_original/ODS1Stage/tables/Base/CityStatePostalCode/spu_translated_CityStatePostalCode.sql
@@ -1,0 +1,206 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_CITYSTATEPOSTALCODE() 
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+    
+-- Base.CityStatePostalCode depends on: 
+--- Raw.OFFICE_PROFILE_PROCESSING
+--- Raw.FACILITY_OFFICE_PROCESSING
+--- Base.Facility
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+    select_statement_1 STRING; -- CTE and Select statement for the Merge
+    insert_statement_1 STRING; -- Insert statement for the Merge
+    merge_statement_1 STRING; -- Merge statement to final table
+    select_statement_2 STRING; -- CTE and Select statement for the Merge
+    insert_statement_2 STRING; -- Insert statement for the Merge
+    merge_statement_2 STRING; -- Merge statement to final table
+    status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    -- no conditionals
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+--- Select Statement
+select_statement_1 := $$ WITH CTE_OfficeJSON AS (
+                            SELECT
+                                Process.CREATED_DATETIME AS CREATE_DATE,
+                                -- Process.RELTIO_ID AS ReltioEntityId,
+                                Process.REF_OFFICE_CODE AS OfficeCode,
+                                -- Process.OfficeID,
+                                Process.OFFICE_PROFILE:ADDRESS AS OfficeJSONAddress,
+                                Process.OFFICE_PROFILE:DEMOGRAPHICS AS OfficeJSONDemographics,
+                                    TO_VARCHAR(OfficeJSONAddress[0].ADDRESS_TYPE_CODE) AS AddressTypeCode,
+                                    TO_VARCHAR(OfficeJSONDemographics[0].OFFICE_NAME) AS OfficeName,
+                                    -- TO_NUMBER(OfficeJSON[0].RANK) AS AddressRank,
+                                    TO_VARCHAR(OfficeJSONAddress[0].ADDRESS_LINE_1) AS AddressLine1,
+                                    TO_VARCHAR(OfficeJSONAddress[0].ADDRESS_LINE_2) AS AddressLine2,
+                                    TO_VARCHAR(OfficeJSONAddress[0].SUITE) AS Suite,
+                                    TO_VARCHAR(OfficeJSONAddress[0].CITY) AS City,
+                                    TO_VARCHAR(OfficeJSONAddress[0].STATE) AS State,
+                                    TO_VARCHAR(OfficeJSONAddress[0].ZIP) AS PostalCode,
+                                    TO_VARCHAR(OfficeJSONAddress[0].LATITUDE) AS Latitude,
+                                    TO_VARCHAR(OfficeJSONAddress[0].LONGITUDE) AS Longitude,
+                                    TO_VARCHAR(OfficeJSONAddress[0].TIME_ZONE) AS TimeZone,
+                                    -- TO_BOOLEAN(OfficeJSON[0].DO_SUPPRESS) AS DoSuppress,
+                                    -- TO_BOOLEAN(OfficeJSON[0].IS_DERIVED) AS IsDerived,
+                                    TO_TIMESTAMP_NTZ(OfficeJSONAddress[0].UPDATED_DATETIME) AS LastUpdateDate,
+                                    TO_VARCHAR(OfficeJSONDemographics[0].OFFICE_CODE) AS OfficeCode,
+                                    TO_VARCHAR(OfficeJSONDemographics[0].DATA_SOURCE_CODE) AS SourceCode
+                            FROM
+                                -- Raw.OfficeProfileProcessingDeDup AS DeDup
+                                Raw.OFFICE_PROFILE_PROCESSING AS Process 
+                            WHERE
+                                Process.OFFICE_PROFILE IS NOT NULL AND 
+                                OfficeJSONAddress IS NOT NULL AND
+                                OfficeJSONDemographics IS NOT NULL AND 
+                                -- IFNULL(DoSuppress, 0) = 0 
+                                    NULLIF(City,'') IS NOT NULL 
+                                    AND NULLIF(State,'') IS NOT NULL 
+                                    AND NULLIF(PostalCode,'') IS NOT NULL
+                                    AND LENGTH(TRIM(UPPER(AddressLine1)) || IFNULL(TRIM(UPPER(AddressLine2)),'') || IFNULL(TRIM(UPPER(Suite)),'')) > 0
+                                        
+                            )
+                            SELECT DISTINCT
+                                    CASE WHEN TRIM(City) LIKE '%,' THEN LEFT(TRIM(City), LENGTH(City)-1) ELSE City END AS City,
+                                    State,
+                                    PostalCode
+                            FROM CTE_OfficeJSON $$;
+
+
+
+--- Insert Statement
+insert_statement_1 := ' INSERT (
+                                CityStatePostalCodeId,
+                                City,
+                                State,
+                                PostalCode,
+                                LastUpdateDate
+                        )
+                        VALUES (
+                                UUID_STRING(),
+                                source.city,
+                                source.state,
+                                source.postalcode,
+                                CURRENT_TIMESTAMP()
+                        )';
+
+select_statement_2 := $$ WITH CTE_FacilityJSON AS (
+                                SELECT
+                                    Facility.FacilityID,
+                                    Process.CREATED_DATETIME AS CREATE_DATE,
+                                    -- Process.RELTIO_ID AS ReltioEntityId,
+                                    Process.REF_FACILITY_CODE AS FacilityCode,
+                                    -- Process.FacilityID,
+                                    Process.FACILITY_PROFILE:ADDRESS AS FacilityJSONAddress,
+                                    Process.FACILITY_PROFILE:DEMOGRAPHICS AS FacilityJSONDemographics,
+                                        TO_VARCHAR(FacilityJSONAddress[0].ADDRESS_LINE_1) AS AddressLine1,
+                                        TO_VARCHAR(FacilityJSONAddress[0].CITY) AS City,
+                                        TO_VARCHAR(FacilityJSONAddress[0].STATE) AS State,
+                                        -- TO_VARCHAR(FacilityJSONAddress[0].COUNTRY) AS Country,
+                                        TO_VARCHAR(FacilityJSONAddress[0].ZIP) AS PostalCode,
+                                        TO_VARCHAR(FacilityJSONAddress[0].LATITUDE) AS Latitude,
+                                        TO_VARCHAR(FacilityJSONAddress[0].LONGITUDE) AS Longitude,
+                                        TO_TIMESTAMP_NTZ(FacilityJSONAddress[0].UPDATED_DATETIME) AS LastUpdateDate,
+                                        TO_VARCHAR(FacilityJSONDemographics[0].DATA_SOURCE_CODE) AS SourceCode
+                                FROM
+                                    -- Raw.FacilityProfileProcessingDeDup AS DeDup
+                                    Raw.FACILITY_PROFILE_PROCESSING AS Process 
+                                JOIN Base.Facility AS Facility ON Process.REF_FACILITY_CODE = Facility.FacilityCode
+                                WHERE
+                                    Process.FACILITY_PROFILE IS NOT NULL AND 
+                                    FacilityJSONAddress IS NOT NULL AND
+                                    FacilityJSONDemographics IS NOT NULL AND 
+                                        NULLIF(City,'') IS NOT NULL 
+                                        AND NULLIF(State,'') IS NOT NULL 
+                                        AND NULLIF(PostalCode,'') IS NOT NULL)
+                                SELECT DISTINCT 
+                                    FacilityID,
+                                    AddressLine1,
+                                    City,
+                                    State,
+                                    -- Country,
+                                    PostalCode,
+                                    Latitude,
+                                    Longitude,
+                                    SourceCode,
+                                    FacilityCode,
+                                    ROW_NUMBER() OVER(PARTITION BY FacilityID ORDER BY CREATE_DATE DESC) AS RowRank
+                                FROM CTE_FacilityJSON $$;
+
+insert_statement_2 := $$INSERT (
+                            CityStatePostalCodeId, 
+                            City, 
+                            State, 
+                            PostalCode, 
+                            CentroidLatitude, 
+                            CentroidLongitude, 
+                            NationId, 
+                            LastUpdateDate
+                        )
+                        VALUES 
+                        (   UUID_STRING(), 
+                            source.City, 
+                            source.State, 
+                            source.PostalCode, 
+                            source.Latitude, 
+                            source.Longitude, 
+                            '00415355-0000-0000-0000-000000000000', 
+                            CURRENT_TIMESTAMP()
+                        );$$;
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+
+merge_statement_1 := ' MERGE INTO Base.CityStatePostalCode as target USING 
+                   ('||select_statement_1||') as source 
+                   ON source.city = target.city AND source.state = target.state AND source.postalcode = target.postalcode
+                   WHEN NOT MATCHED THEN '||insert_statement_1;
+
+merge_statement_2 := ' MERGE INTO Base.CityStatePostalCode as target USING 
+                   ('||select_statement_2||') as source 
+                   ON source.city = target.city AND source.state = target.state AND source.postalcode = target.postalcode
+                   WHEN NOT MATCHED THEN '||insert_statement_2;
+                   
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+                    
+EXECUTE IMMEDIATE merge_statement_1 ;
+EXECUTE IMMEDIATE merge_statement_2 ;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+    
+END;
+


### PR DESCRIPTION
-- The date format of Raw.OfficeProfileProcessingDeDup of the column CREATE_DATE is not correct, needs to be fixed
-- The update regarding Base.State does not apply anymore as the StateName comes in the format of PR instead of Puerto Rico
-- There are values in the new json that are not there. Ex: the values of Rank,  DoSupress, and IsDerived from AddressJSON in Office entity do not exist now, also Country from FacilityJSON
-- The new JSON has longitude and latitude values like integers instead of having decimals, these makes these two columns have different values than the original ones
-- The citystatepostalcodeid is created by a function UUUID_STRING so it is not exactly the same as in sql server
-- There are many columns that we don't know where they come from and they don't get updated like: URLCity, County, IsCITYALIAS, CityType, PopulationClass
--- rawfile.spumergeofficepractice is updating CityStatePostalCodeID, City, State, PostalCode, URLCity
--- fastpass.spumergeaddress is updating CityStatePostalCodeId, City, State, PostalCode, URLCity, NationID, LastUpdateDate