### PR TITLE
Base.vwuPDCClientDetail

### DIFF
--- a/migration_original/ODS1Stage/views/Base/vwuPDCClientDetail/vwuPDCClientDetail_original.sql
+++ b/migration_original/ODS1Stage/views/Base/vwuPDCClientDetail/vwuPDCClientDetail_original.sql
@@ -1,0 +1,89 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+
+CREATE VIEW [Base].[vwuPDCClientDetail] 
+
+AS
+
+/*-------------------------------------------------------------------------------------------------------------
+View Name		vwuPDCClientDetail
+
+Created By		Abhash Bhandary
+Created On		23rd Feb 2012
+
+Description		This view will result the PDC clients's detail
+
+Modified By     EGS
+Modified On     5/16/12
+Modification    Changed image (alias img) sub-query to point to new image tables
+
+Server			
+
+TEST EXAMPLE(S)
+SELECT * FROM [Base].[vwuPDCClientDetail] WHERE ClientToProductID = '5D6F65D5-F03D-4AA3-BE1E-45657799B4B0'
+SELECT * FROM [Base].[vwuPDCClientDetail_abhash] WHERE ClientToProductID = '5D6F65D5-F03D-4AA3-BE1E-45657799B4B0'
+
+----------------------------------------------------------------------------------------------------------------*/
+
+
+SELECT	b.ClientToProductID,m.ClientProductToEntityID, img.ImageFilePath, img.MediaImageTypeCode ,u.URL,u.URLTypeCode,
+		--MAX(CASE WHEN ph.AreaCode > 1000 THEN ('1-'+CAST(ph.AreaCode - 1000 AS VARCHAR(5)) +'-'+ph.PhoneNumber) ELSE  (( '('+CAST(ph.AreaCode AS VARCHAR(5)) ) +') '+ph.PhoneNumber)END ) AS  'DesignatedProviderPhone',
+		ph.PhoneNumber AS  'DesignatedProviderPhone',
+		ph.PhoneTypeCode
+-- SELECT *  
+FROM	Base.Client a
+		JOIN Base.ClientToProduct b  ON a.ClientID = b.ClientID AND b.ActiveFlag = 1
+		JOIN Base.ClientProductToEntity m ON b.ClientToProductID = m.ClientToProductID 
+		JOIN Base.EntityType c ON m.EntityTypeID = c.EntityTypeID AND c.EntityTypeCode = 'CLPROD'
+		LEFT JOIN
+				(
+                    select d.ClientToProductID, 
+                    isnull(e.MediaRelativePath,'') + case when right(isnull(e.MediaRelativePath,''),1) <> '/' then '/' else '' end + d.FileName as ImageFilePath, 
+                        e.MediaImageTypeCode 
+                    from Base.ClientProductImage d
+                    inner join Base.MediaImageType e on e.MediaImageTypeID = d.MediaImageTypeID
+				) img ON b.ClientToProductID = img.ClientToProductID
+		
+		LEFT JOIN 
+		(
+			SELECT g.ClientProductToEntityID, 
+			ltrim(rtrim(replace(i.URL,'--','-'))) as URL,
+			h.URLTypeCode
+			FROM Base.ClientProductEntityToURL g 
+			JOIN Base.URLType h ON h.URLTypeID = g.URLTypeID --AND h.URLTypeCode = 'ClientURL'
+			JOIN Base.URL i ON g.URLID = i.URLID
+			
+		) u ON m.ClientProductToEntityID = u.ClientProductToEntityID 
+				
+		--LEFT JOIN 
+		--(
+			
+		--	SELECT j.ClientProductToEntityID, cpe.ClientToProductID, l.AreaCode, l.PhoneNumber, k.PhoneTypeCode
+		--	FROM Base.ClientProductEntityToPhone j 
+		--	JOIN Base.PhoneType k ON j.PhoneTypeID = k.PhoneTypeID --AND k.PhoneTypeCode IN ( 'PDC Affiliated', 'Client-Employed')
+		--	JOIN Base.Phone l ON j.PhoneID = l.PhoneID
+		--	JOIN Base.ClientProductToEntity cpe on j.ClientProductToEntityID = cpe.ClientProductToEntityID
+		--	--where J.ClientToProductID = m.ClientToProductID
+		--) ph ON m.ClientToProductID = ph.ClientToProductID
+
+		LEFT JOIN 
+		(
+			
+			SELECT j.ClientProductToEntityID, cpe.ClientToProductID, j.AreaCode, j.PhoneNumber, j.PhoneTypeCode
+			FROM [Base].[vwuClientProductEntityToPhone] j 
+			JOIN Base.ClientProductToEntity cpe on j.ClientProductToEntityID = cpe.ClientProductToEntityID
+			--where J.ClientToProductID = m.ClientToProductID
+		) ph ON m.ClientToProductID = ph.ClientToProductID
+
+
+
+
+
+
+
+
+GO

--- a/migration_original/ODS1Stage/views/Base/vwuPDCClientDetail/vwuPDCClientDetail_translated.sql
+++ b/migration_original/ODS1Stage/views/Base/vwuPDCClientDetail/vwuPDCClientDetail_translated.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE VIEW ODS1_STAGE.BASE.VWUPDCCLIENTDETAIL
+AS 
+
+WITH CTE_images AS (
+    SELECT
+        cpi.ClientToProductID,
+        CONCAT(
+            COALESCE(mit.MediaRelativePath, ''),
+            '/',
+            cpi.FileName
+        ) AS ImageFilePath,
+        mit.MediaImageTypeCode
+    FROM Base.ClientProductImage cpi
+    INNER JOIN Base.MediaImageType mit ON mit.MediaImageTypeID = cpi.MediaImageTypeID
+),
+
+CTE_urls AS (
+    SELECT
+        cpeturl.ClientProductToEntityID,
+        TRIM(REPLACE(u.URL, '--', '-')) AS URL,
+        ut.URLTypeCode
+    FROM Base.ClientProductEntityToURL cpeturl
+    INNER JOIN Base.URLType ut ON ut.URLTypeID = cpeturl.URLTypeID
+    INNER JOIN Base.URL u ON cpeturl.URLID = u.URLID
+),
+
+CTE_phones AS (
+    SELECT
+        vw.ClientProductToEntityID,
+        cpte.ClientToProductID,
+        vw.AreaCode,
+        vw.PhoneNumber,
+        vw.PhoneTypeCode
+    FROM Base.vwuClientProductEntityToPhone vw
+    INNER JOIN Base.ClientProductToEntity cpte ON vw.ClientProductToEntityID = cpte.ClientProductToEntityID
+)
+
+SELECT
+    ctp.ClientToProductID,
+    cpte.ClientProductToEntityID,
+    img.ImageFilePath,
+    img.MediaImageTypeCode,
+    u.URL,
+    u.URLTypeCode,
+    ph.PhoneNumber AS DesignatedProviderPhone,
+    ph.PhoneTypeCode
+FROM Base.Client c
+INNER JOIN Base.ClientToProduct ctp ON c.ClientID = ctp.ClientID AND ctp.ActiveFlag = 1
+INNER JOIN Base.ClientProductToEntity cpte ON ctp.ClientToProductID = cpte.ClientToProductID
+INNER JOIN Base.EntityType et ON cpte.EntityTypeID = et.EntityTypeID AND et.EntityTypeCode = 'CLPROD'
+LEFT JOIN CTE_images img ON ctp.ClientToProductID = img.ClientToProductID
+LEFT JOIN CTE_urls u ON cpte.ClientProductToEntityID = u.ClientProductToEntityID
+LEFT JOIN CTE_phones ph ON cpte.ClientProductToEntityID = ph.ClientProductToEntityID;


### PR DESCRIPTION
Similar to other views programmatic validation is tricky at this point because we are creating IDs in other procs. Most of the logic stayed the same (besides changing things like subqueries to CTEs and aliases), only notable difference is I built the ImageFilePath with a COALESCE command instead so it's more compact. Did some manual validation querying the view from SQL Server and the outputs match. 