### PR TITLE
Base.ProviderRedirect

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProviderRedirect/spu_original_ProviderRedirect.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderRedirect/spu_original_ProviderRedirect.sql
@@ -1,0 +1,10 @@
+-- a bunch of code creating the temporary version of Mid.Provider ...
+-- to then update Base.ProviderRedirect.ProviderURLNew with the new value from Mid.Provider.ProviderURL
+
+update		a set a.ProviderURLNew = b.ProviderURL
+FROM		Base.ProviderRedirect a
+INNER JOIN	#Provider b -- Temp version of Mid.Provider
+            on b.ProviderCode = a.ProviderCodeNew
+WHERE		a.ProviderURLNew is not null
+            AND b.ProviderURL != a.ProviderURLNew
+            AND a.DeactivationReason not in ('Deactivated','HomePageRedirect')

--- a/migration_original/ODS1Stage/tables/Base/ProviderRedirect/spu_translated_ProviderRedirect.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderRedirect/spu_translated_ProviderRedirect.sql
@@ -1,0 +1,78 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_PROVIDERREDIRECT()
+RETURNS VARCHAR(16777216)
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS 
+
+DECLARE
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+--- Base.ProviderRedirect depends on:
+-- Mid.Provider (yes, this is not a typo...)
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+select_statement STRING;
+update_statement STRING;
+merge_statement STRING;
+status STRING;
+
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+
+BEGIN
+-- no conditionals
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+select_statement := $$
+                    SELECT p.ProviderCode, p.ProviderURL
+                    FROM Mid.Provider p
+                    INNER JOIN Base.ProviderRedirect pr ON p.ProviderCode = pr.ProviderCodeNew
+                    WHERE pr.ProviderURLNew IS NOT NULL
+                        AND p.ProviderURL != pr.ProviderURLNew
+                        AND pr.DeactivationReason NOT IN ('Deactivated', 'HomePageRedirect')
+                    $$;
+
+update_statement := $$ 
+                    UPDATE SET ProviderURLNew = source.ProviderURL
+                    $$;
+
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+merge_statement := $$ MERGE INTO Base.ProviderRedirect as target 
+                    USING ($$||select_statement||$$) as source 
+                    ON source.ProviderCode = target.ProviderCodeNew
+                    WHEN MATCHED THEN $$ ||update_statement||$$;
+                    $$;
+
+
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE merge_statement;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+END;


### PR DESCRIPTION
This one is an example of danger. It's not super important since it seems only UPDATEs are made to this table, but they happen in a MID stored procedure using a JOIN with the *temporary version of MID.PROVIDER*. Since we are isolating the orchestration at a table-level, one way would be to copy paste and replicate the temporary version of MID.PROVIDER here. But this is a waste of compute, I think the best way to do this is ensuring ProviderRedirect runs AFTER Provider in the orchestration (which is what makes sense in general). Doing this we can then simply do the JOIN with MID.PROVIDER and not its temporary version. 

Also fun fact I found a new way to perform an UPDATE with JOINs (putting them in the SELECT). 