### PR TITLE
Base.ProvidersWithSponsorshipIssues

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProvidersWithSponsorshipIssues/spu_original_ProvidersWithSponsorshipIssues.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProvidersWithSponsorshipIssues/spu_original_ProvidersWithSponsorshipIssues.sql
@@ -1,0 +1,150 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+create procedure [Mid].[spuRecordPostRulesEngineDataIssues]
+as
+/*-------------------------------------------------------------------------------------------------------------
+Created By    : Erik Shaw
+Created On    : 8/28/17
+Description   : Record a list of Post-RulesEngine issues into Base.ProvidersWithSponsorshipIssues
+
+Test:
+    exec Mid.spuRecordPostRulesEngineDataIssues
+
+--------------------------------------------------------------------------------------------------------------*/
+declare @_ErrorProcedure varchar(max), @_ErrorLine int, @_ErrorMessage varchar(1000), @IssueDescription varchar(max)
+
+begin try
+    --Base.ProvidersWithSponsorshipIssues is reset every time this proc is run
+    truncate table Base.ProvidersWithSponsorshipIssues
+
+    --http://hgprodbiapp01/ReportServer/Pages/ReportViewer.aspx?%2fOperational+Monitoring%2fTest+Case+Result+Detail&TestCaseId=744&TestCaseBatchId=373852
+    --ODS_Mid: Providers should only have a max of one sponsorship
+
+    /*
+        select distinct ProviderCode, ClientCode  
+         from  mid.providersponsorship
+         WHERE ProductCode<>'lid'
+
+        select providercode, COUNT(*) as sponsors from $1  group by providercode having COUNT(*) > 1
+    */
+    create table #provider (ProviderCode varchar(50) primary key clustered)
+
+    truncate table #provider        
+
+    insert into #provider (ProviderCode)
+    select distinct ProviderCode
+    from
+    (
+        select ProviderCode, ClientCode
+        from ODS1Stage.Mid.ProviderSponsorship with (nolock)
+        where ProductCode <> 'lid'
+        group by ProviderCode, ClientCode
+    ) as y
+    group by ProviderCode
+    having count(*) > 1
+    order by ProviderCode
+
+    if @@ROWCOUNT > 0 begin
+        set @IssueDescription = 'Non-LID Provider has more than one sponsorship record in ODS1Stage.Mid.ProviderSponsorship'
+
+        insert into Base.ProvidersWithSponsorshipIssues (ProviderCode, IssueDescription)
+        select p.ProviderCode, @IssueDescription
+        from #provider as p
+        where not exists (select 1 from Base.ProvidersWithSponsorshipIssues as i where i.ProviderCode = p.ProviderCode and i.IssueDescription = @IssueDescription)
+    end
+
+    ------------------------------------------------------------------------------------------------------------------------------------------------
+    --http://hgprodbiapp01/ReportServer/Pages/ReportViewer.aspx?%2fOperational+Monitoring%2fTest+Case+Result+Detail&TestCaseId=745&TestCaseBatchId=373852
+    --ODS_Mid: Providers for PDC-Practice having no Office/Practice sponsorship data
+    /*
+	
+        SELECT            [ProviderCode]
+        FROM              [ODS1Stage].[Mid].[ProviderSponsorship]
+        WHERE            [ProductCode] = 'PDCPRAC'
+                                AND OfficeCode IS NULL
+    */
+    truncate table #provider        
+
+    insert into #provider (ProviderCode)
+    select distinct ProviderCode
+    from ODS1Stage.Mid.ProviderSponsorship with (nolock)
+    where ProductCode = 'PDCPRAC' and OfficeCode is null
+    order by ProviderCode
+
+    if @@ROWCOUNT > 0 begin
+        set @IssueDescription = 'PDCPRAC Provider has a null OfficeCode in ODS1Stage.Mid.ProviderSponsorship'
+
+        insert into Base.ProvidersWithSponsorshipIssues (ProviderCode, IssueDescription)
+        select p.ProviderCode, @IssueDescription
+        from #provider as p
+        where not exists (select 1 from Base.ProvidersWithSponsorshipIssues as i where i.ProviderCode = p.ProviderCode and i.IssueDescription = @IssueDescription)
+    end
+
+    ------------------------------------------------------------------------------------------------------------------------------------------------
+    --http://hgprodbiapp01/ReportServer/Pages/ReportViewer.aspx?%2fOperational+Monitoring%2fTest+Case+Result+Detail&TestCaseId=746&TestCaseBatchId=373852
+    --ODS_Mid: PhoneXML is NULL in Mid.ProviderSponsorship for PDC Hospital
+    /*
+        SELECT ps.providercode,ClientCode,ClientName,p.FirstName,p.LastName--,*
+        FROM mid.providersponsorship ps with(nolock)
+        join Mid.Provider p with(nolock) on p.ProviderCode = ps.ProviderCode
+        WHERE ProductCode in ('PDCHSP','PDCPRAC')
+        AND PhoneXML is NULL
+    */
+    truncate table #provider        
+
+    insert into #provider (ProviderCode)
+    select distinct ps.ProviderCode
+    from ODS1Stage.Mid.ProviderSponsorship ps with (nolock)
+    join ODS1Stage.Mid.Provider p with (nolock) on p.ProviderCode = ps.ProviderCode
+    where ps.ProductCode in ('PDCHSP', 'PDCPRAC') and ps.PhoneXML is null
+    order by ProviderCode
+
+    if @@ROWCOUNT > 0 begin
+        set @IssueDescription = 'PDCHSP/PDCPRAC Provider has more a null PhoneXML in ODS1Stage.Mid.ProviderSponsorship'
+
+        insert into Base.ProvidersWithSponsorshipIssues (ProviderCode, IssueDescription)
+        select p.ProviderCode, @IssueDescription
+        from #provider as p
+        where not exists (select 1 from Base.ProvidersWithSponsorshipIssues as i where i.ProviderCode = p.ProviderCode and i.IssueDescription = @IssueDescription)
+    end
+
+    ------------------------------------------------------------------------------------------------------------------------------------------------
+    --http://hgprodbiapp01/ReportServer/Pages/ReportViewer.aspx?%2fOperational+Monitoring%2fTest+Case+Result+Detail&TestCaseId=747&TestCaseBatchId=373852
+    --ODS_Mid: FacilityCode is NULL in Mid.ProviderSponsorship for PDC Hospital
+    /*
+        SELECT ps.providercode,ClientCode,ClientName,p.FirstName,p.LastName--,*
+        FROM mid.providersponsorship ps with(nolock)
+        join Mid.Provider p with(nolock) on p.ProviderCode = ps.ProviderCode
+        WHERE ProductCode = 'PDCHSP'
+        AND FacilityCode IS NULL
+    */
+    truncate table #provider        
+
+    insert into #provider (ProviderCode)
+    select distinct ps.ProviderCode
+    from ODS1Stage.Mid.ProviderSponsorship ps with (nolock)
+    join ODS1Stage.Mid.Provider p with (nolock) on p.ProviderCode = ps.ProviderCode
+    where ps.ProductCode = 'PDCHSP' and ps.FacilityCode is null
+    order by ProviderCode
+
+    if @@ROWCOUNT > 0 begin
+        set @IssueDescription = 'PDCHSP Provider has a null FacilityCode in ODS1Stage.Mid.ProviderSponsorship'
+
+        insert into Base.ProvidersWithSponsorshipIssues (ProviderCode, IssueDescription)
+        select p.ProviderCode, @IssueDescription
+        from #provider as p
+        where not exists (select 1 from Base.ProvidersWithSponsorshipIssues as i where i.ProviderCode = p.ProviderCode and i.IssueDescription = @IssueDescription)
+    end
+
+    ------------------------------------------------------------------------------------------------------------------------------------------------
+
+end try     
+begin catch
+    select @_ErrorProcedure = object_name(@@PROCID), @_ErrorLine = error_line(), @_ErrorMessage = error_message()
+    raiserror('Error in procedure %s on line %i: %s', 18, 1, @_ErrorProcedure, @_ErrorLine, @_ErrorMessage)
+end catch
+
+GO

--- a/migration_original/ODS1Stage/tables/Base/ProvidersWithSponsorshipIssues/spu_translated_ProvidersWithSponsorshipIssues.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProvidersWithSponsorshipIssues/spu_translated_ProvidersWithSponsorshipIssues.sql
@@ -1,0 +1,127 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_PROVIDERLSWITHSPONSORSHIPISSUES()
+RETURNS VARCHAR(16777216)
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS 
+
+DECLARE
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+--- Base.ProvidersWithSponsorshipIssues depends on:
+-- Mid.ProviderSponsorship
+-- Mid.Provider
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+select_statement STRING;
+insert_statement STRING;
+update_statement STRING;
+merge_statement STRING;
+status STRING;
+
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------  
+BEGIN
+-- no conditionals
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+select_statement := $$
+                    WITH CTE_ProviderWithMultipleSponsorships AS (
+                        SELECT ProviderCode
+                        FROM Mid.ProviderSponsorship
+                        WHERE ProductCode <> 'LID'
+                        GROUP BY ProviderCode
+                        HAVING COUNT(DISTINCT ClientCode) > 1
+                    ),
+                    
+                    CTE_ProviderWithNullOfficeCode AS (
+                        SELECT DISTINCT ProviderCode
+                        FROM Mid.ProviderSponsorship
+                        WHERE ProductCode = 'PDCPRAC' AND OfficeCode IS NULL
+                    ),
+                    
+                    CTE_ProviderWithNullPhoneXML AS (
+                        SELECT DISTINCT ps.ProviderCode
+                        FROM Mid.ProviderSponsorship ps
+                        JOIN Mid.Provider p ON p.ProviderCode = ps.ProviderCode
+                        WHERE ps.ProductCode IN ('PDCHSP', 'PDCPRAC') AND ps.PhoneXML IS NULL
+                    ),
+                    
+                    CTE_ProviderWithNullFacilityCode AS (
+                        SELECT DISTINCT ps.ProviderCode
+                        FROM Mid.ProviderSponsorship ps
+                        JOIN Mid.Provider p ON p.ProviderCode = ps.ProviderCode
+                        WHERE ps.ProductCode = 'PDCHSP' AND ps.FacilityCode IS NULL
+                    ),
+                    
+                    CTE_AllIssues AS (
+                        SELECT ProviderCode, 'Non-LID Provider has more than one sponsorship record in ODS1Stage.Mid.ProviderSponsorship' AS IssueDescription
+                        FROM CTE_ProviderWithMultipleSponsorships
+                        UNION ALL
+                        SELECT ProviderCode, 'PDCPRAC Provider has a null OfficeCode in ODS1Stage.Mid.ProviderSponsorship'
+                        FROM CTE_ProviderWithNullOfficeCode 
+                        UNION ALL
+                        SELECT ProviderCode, 'PDCHSP/PDCPRAC Provider has a null PhoneXML in ODS1Stage.Mid.ProviderSponsorship'
+                        FROM CTE_ProviderWithNullPhoneXML
+                        UNION ALL
+                        SELECT ProviderCode, 'PDCHSP Provider has a null FacilityCode in ODS1Stage.Mid.ProviderSponsorship'
+                        FROM CTE_ProviderWithNullFacilityCode
+                    )
+                    
+                    SELECT ProviderCode, IssueDescription
+                    FROM CTE_AllIssues
+                    $$;
+
+insert_statement := $$ 
+                    INSERT
+                        (
+                        ProviderCode, 
+                        IssueDescription
+                        )
+                     VALUES 
+                        (
+                        source.ProviderCode,
+                        source.IssueDescription
+                        )
+                     $$;
+
+update_statement := $$
+                    UPDATE SET target.IssueDescription= source.IssueDescription
+                    $$;
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+merge_statement := $$ MERGE INTO Base.ProvidersWithSponsorshipIssues as target 
+                    USING ($$||select_statement||$$) as source 
+                    ON source.ProviderCode = target.ProviderCode
+                    WHEN MATCHED THEN $$||update_statement||$$
+                    WHEN NOT MATCHED THEN $$ ||insert_statement;
+
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE merge_statement;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+END;


### PR DESCRIPTION
This one may be out of scope since it consumes an out of scope table but I'd already started it anyway and it's being updated in SQL Server since a few days ago it had ~30 rows and today it has 1 - validation is tricky. It's also a base table taking data from mid (*danger). 

Changed the logic a little bit but the DML is doing the same thing - instead of string matching based on the IssueDescription column I always insert/update that column in the merge. 