### PR TITLE
base.providermalpractice

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProviderMalpractice/spu_original_ProviderMalpractice.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderMalpractice/spu_original_ProviderMalpractice.sql
@@ -1,0 +1,134 @@
+-- etl.spumergeprovidermalpractice
+begin
+    declare @FiveYearsAgo datetime = dateadd(year, -5, getdate())
+
+	if object_id('tempdb..#swimlane') is not null drop table #swimlane
+    select distinct y.ClaimAmount, y.ClaimDate, y.ClaimNumber, y.ClaimState, y.ClaimYear, y.ClosedDate, y.Complaint, x.ProviderCode,
+        case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end as ProviderID,
+        convert(uniqueidentifier, convert(varbinary(20), LTRIM(RTRIM(y.MalpracticeClaimTypeCode)))) as MalpracticeClaimTypeID, LTRIM(RTRIM(y.MalpracticeClaimTypeCode)) as MalpracticeClaimTypeCode,
+        convert(uniqueidentifier, convert(varbinary(20), y.ProviderLicenseCode)) as ProviderLicenseID, y.ProviderLicenseCode,
+        y.DoSuppress, y.IncidentDate, y.LastUpdateDate, y.LicenseNumber, y.MalpracticeClaimRange, y.ReportDate, y.SourceCode, 
+        row_number() over(partition by (case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end), LTRIM(RTRIM(y.MalpracticeClaimTypeCode)), y.ClaimDate, y.ClaimYear, y.ClaimState, y.LicenseNumber, y.MalpracticeClaimRange order by x.CREATE_DATE desc, y.ClaimAmount desc) as RowRank, --Used existing de duping logic from Rules Engine
+	    row_number()over(order by (case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end)) as RN1
+    into #swimlane
+    from
+    (
+        select w.* 
+        from
+        (
+            select p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.PROVIDER_CODE as ProviderCode, p.ProviderID, 
+                json_query(p.PAYLOAD, '$.EntityJSONString.Malpractice') as ProviderJSON
+            from raw.ProviderProfileProcessingDeDup as d with (nolock)
+            inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+            where p.PAYLOAD is not null and p.Reltio_ID <> '5CriggW'
+        ) as w
+        where w.ProviderJSON is not null
+    ) as x
+    left join ODS1Stage.Base.Provider as pID on pID.ProviderCode = x.ProviderCode
+    cross apply 
+    (
+        select *
+        from openjson(x.ProviderJSON) with (ClaimAmount varchar(50) '$.ClaimAmount', ClaimDate varchar(50) '$.ClaimDate', 
+            ClaimNumber varchar(30) '$.ClaimNumber', ClaimState varchar(2) '$.ClaimState', ClaimYear varchar(50) '$.ClaimYear', 
+            ClosedDate varchar(50) '$.ClosedDate', Complaint varchar(2000) '$.Complaint', DoSuppress bit '$.DoSuppress', 
+            IncidentDate varchar(50) '$.IncidentDate', LastUpdateDate varchar(50) '$.LastUpdateDate', 
+            LicenseNumber varchar(50) '$.LicenseNumber', MalpracticeClaimRange varchar(50) '$.MalpracticeClaimRange', 
+            MalpracticeClaimTypeCode varchar(50) '$.ClaimTypeCode',  
+            ProviderLicenseCode varchar(50) '$.ProviderLicenseCode', 
+            ReportDate varchar(50) '$.ReportDate', SourceCode varchar(25) '$.SourceCode', IsActiveMalpractice bit '$.Status')
+    ) as y
+
+	delete s
+    --select *
+    from #swimlane as s
+    where isnumeric(isnull(s.ClaimAmount,0)) = 0
+
+	--Protects the ODS1Stage table from numeric overload. 
+	--Per Sandy Davis the Malpractice system is getting an overhaul so this happy hacky bullshit is acceptable.
+	update s set s.ClaimAmount = '99999999.99'
+	from #swimlane as s 
+	where convert(decimal(15,2), claimAmount) >= 100000000
+
+	--update top (1) #swimlane  set MalpracticeClaimTypeCode  = 'test'
+	IF OBJECT_ID('tempdb..##BadMalpracticeClaimTypeCode') IS NOT NULL DROP TABLE ##BadMalpracticeClaimTypeCode
+	SELECT		DISTINCT P.ProviderCode, 'Bad Malpractice Claim Type Code value of ' + ISNULL(S.MalpracticeClaimTypeCode,'NULL')  AS ProblemType, RN1
+	INTO		##BadMalpracticeClaimTypeCode
+	FROM		#swimlane S
+	INNER JOIN	ODS1Stage.Base.Provider P 
+				ON P.ProviderId = S.ProviderId
+	LEFT JOIN	ODS1Stage.Base.MalpracticeClaimType MCT
+				ON MCT.MalpracticeClaimTypeCode = S.MalpracticeClaimTypeCode
+	WHERE		MCT.MalpracticeClaimTypeId IS NULL
+	UNION
+	SELECT		DISTINCT P.ProviderCode, 'Bad Malpractice Claim Type Code value of ' + ISNULL(S.MalpracticeClaimTypeCode,'NULL')  AS ProblemType, RN1
+	FROM		#swimlane S
+	INNER JOIN	ODS1Stage.Base.Provider P 
+				ON P.ProviderId = S.ProviderId
+	LEFT JOIN	ODS1Stage.Base.MalpracticeClaimType MCT
+				ON MCT.MalpracticeClaimTypeID = S.MalpracticeClaimTypeID
+	WHERE		MCT.MalpracticeClaimTypeId IS NULL	
+	UNION
+	SELECT	S.ProviderCode, 'Bad IncidentDate value: ' + cast(IncidentDate as varchar(100)) , RN1
+	FROM	#swimlane S
+	WHERE	(ISDATE(IncidentDate) = 0 AND IncidentDate IS NOT NULL)
+	UNION
+	SELECT	S.ProviderCode, 'Bad ReportDate value: ' + cast(ReportDate as varchar(100)) , RN1
+	FROM	#swimlane S
+	WHERE	(ISDATE(ReportDate) = 0 AND ReportDate IS NOT NULL)
+	UNION
+	SELECT	S.ProviderCode, 'Bad ClaimDate value: ' + cast(ClaimDate as varchar(100)) , RN1
+	FROM	#swimlane S
+	WHERE	(ISDATE(ClaimDate) = 0 AND ClaimDate IS NOT NULL)
+	UNION
+	SELECT	S.ProviderCode, 'Bad ClosedDate value: ' + cast(ClosedDate as varchar(100)) , RN1
+	FROM	#swimlane S
+	WHERE	(ISDATE(ClosedDate) = 0 AND ClosedDate IS NOT NULL)
+	UNION
+	SELECT	S.ProviderCode, 'Bad ClaimYear value: ' + cast(ClaimYear as varchar(100))  , RN1
+	FROM	#swimlane S
+	WHERE	(ISNUMERIC(ClaimYear) = 0 AND ClaimYear IS NOT NULL)
+	
+	;WITH CTE_KEEP AS (
+		SELECT	*
+		FROM	#swimlane Y
+		where	(
+					(TRY_convert(datetime,isnull(y.IncidentDate,'1900-01-01'),102) >  dateadd(year, -5, getdate()) --Any of these 4 dates are within 5 years
+										  or TRY_convert(datetime,isnull(y.ReportDate,'1900-01-01'),102) >  dateadd(year, -5, getdate())
+										  or TRY_convert(datetime,isnull(y.ClaimDate,'1900-01-01'),102) >  dateadd(year, -5, getdate()) 
+										  or TRY_convert(datetime,isnull(y.ClosedDate,'1900-01-01'),102) >  dateadd(year, -5, getdate()))
+					or (y.IncidentDate is null and y.ReportDate is null and y.ClaimDate is null and y.ClosedDate is null)  --or all 4 of these dates are null but Claim year is within 5 years
+					and y.ClaimYear is not null and isnumeric(y.ClaimYear) = 1 and TRY_CONVERT(INT, y.ClaimYear) > datepart(year,  dateadd(year, -5, getdate()))
+				)
+	)
+	DELETE #swimlane WHERE RN1 NOT IN (SELECT RN1 FROM CTE_KEEP)
+
+	IF EXISTS(SELECT * FROM ##BadMalpracticeClaimTypeCode)
+	BEGIN
+		DELETE		S
+        --select *
+		FROM		#swimlane S
+		INNER JOIN	##BadMalpracticeClaimTypeCode B
+					ON B.RN1 = S.RN1		
+
+		EXEC msdb..sp_send_dbmail @profile_name='db_mail',
+			@recipients='sandy.davis@healthgrades.com;jarred.armijo@healthgrades.com;ehook@healthgrades.com;dfrisch@healthgrades.com',
+			@subject='Bad Malpractice Information',
+			@body='These records have incorrect values for their field types related to malpractice claims and will be dropped from the provider record. Please correct them in Reltio to secure provider updates for these provider-malpractice records.',
+			@query='SELECT ProviderCode, [ProblemType] FROM ##BadMalpracticeClaimTypeCode'
+	END
+
+    if @OutputDestination = 'ODS1Stage' begin
+	   --Delete all ProviderMalpractice (child) records for all parents in the #swimlane
+	    delete pc
+	    --select *
+	    from raw.ProviderProfileProcessingDeDup as p with (nolock)
+        inner join ODS1Stage.Base.Provider as p2 on p2.ProviderCode = p.ProviderCode
+	    inner join ODS1Stage.Base.ProviderMalpractice as pc on pc.ProviderID = p2.ProviderID
+	
+	    --Insert all ProviderMalpractice child records
+	    insert into ODS1Stage.Base.ProviderMalpractice (ProviderMalpracticeID, ProviderID, ProviderLicenseID, MalpracticeClaimTypeID, ClaimNumber, ClaimDate, ClaimYear, ClaimAmount, ClaimState, MalpracticeClaimRange, Complaint, IncidentDate, ClosedDate, ReportDate, SourceCode, LicenseNumber, LastUpdateDate)
+	    select newid(), s.ProviderID, s.ProviderLicenseID, s.MalpracticeClaimTypeID, s.ClaimNumber, s.ClaimDate, s.ClaimYear, s.ClaimAmount, s.ClaimState, s.MalpracticeClaimRange, s.Complaint, s.IncidentDate, s.ClosedDate, s.ReportDate, isnull(s.SourceCode, 'Profisee'), s.LicenseNumber, isnull(s.LastUpdateDate, getdate())
+	    from #swimlane as s
+	    where s.RowRank = 1
+		and (s.ProviderID is not null and s.MalpracticeClaimTypeID is not null and s.ClaimState is not null)	
+	end

--- a/migration_original/ODS1Stage/tables/Base/ProviderMalpractice/spu_translated_ProviderMalpractice.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderMalpractice/spu_translated_ProviderMalpractice.sql
@@ -1,0 +1,286 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_PROVIDERMALPRACTICE()
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+
+DECLARE 
+
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+-- BASE.ProviderMalpractice depends on:
+--- RAW.VW_PROVIDER_PROFILE
+--- Base.Provider
+--- Base.ProviderLicense
+--- Base.MalpracticeClaimType
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+select_statement STRING;
+insert_statement STRING;
+merge_statement STRING;
+status STRING;
+
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------  
+
+BEGIN
+-- no conditionals
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------
+
+-- Select Statement
+select_statement := $$  WITH CTE_Swimlane AS (SELECT
+    P.ProviderId,
+    PL.ProviderLicenseId,
+    M.MalpracticeClaimTypeID,
+    JSON.ProviderCode,
+    JSON.MALPRACTICE_MALPRACTICECLAIMTYPECODE AS MalpracticeClaimTypeCode,
+    JSON.MALPRACTICE_CLAIMNUMBER AS ClaimNumber,
+    JSON.MALPRACTICE_CLAIMDATE AS ClaimDate,
+    JSON.MALPRACTICE_CLAIMYEAR AS ClaimYear,
+    TO_NUMBER(JSON.MALPRACTICE_CLAIMAMOUNT) AS ClaimAmount,
+    JSON.MALPRACTICE_CLAIMSTATE AS ClaimState,
+    JSON.MALPRACTICE_MALPRACTICECLAIMRANGE AS MalpracticeClaimRange,
+    JSON.MALPRACTICE_COMPLAINT AS Complaint,
+    JSON.MALPRACTICE_INCIDENTDATE AS IncidentDate,
+    JSON.MALPRACTICE_CLOSEDDATE AS ClosedDate,
+    JSON.MALPRACTICE_REPORTDATE AS ReportDate,
+    JSON.MALPRACTICE_SOURCECODE AS SourceCode,
+    JSON.MALPRACTICE_LICENSENUMBER AS LicenseNumber,
+    JSON.MALPRACTICE_LASTUPDATEDATE AS LastUpdateDate,
+    row_number() over(partition by P.ProviderId, JSON.MALPRACTICE_MALPRACTICECLAIMTYPECODE, JSON.MALPRACTICE_CLAIMDATE, JSON.MALPRACTICE_CLAIMYEAR, JSON.MALPRACTICE_CLAIMSTATE, JSON.MALPRACTICE_LICENSENUMBER, JSON.MALPRACTICE_MALPRACTICECLAIMRANGE order by CREATE_DATE desc, TO_NUMBER(JSON.MALPRACTICE_CLAIMAMOUNT) desc) as RowRank, 
+	row_number()over(order by P.ProviderID) as RN1
+FROM
+    RAW.VW_PROVIDER_PROFILE AS JSON
+    LEFT JOIN Base.Provider AS P ON JSON.ProviderCode = P.ProviderCode
+    LEFT JOIN Base.ProviderLicense AS PL ON PL.Providerid = P.ProviderId AND PL.licensenumber = JSON.MALPRACTICE_LICENSENUMBER
+    LEFT JOIN Base.MalpracticeClaimType AS M ON M.MALPRACTICECLAIMTYPECODE = JSON.MALPRACTICE_MALPRACTICECLAIMTYPECODE
+WHERE
+    PROVIDER_PROFILE IS NOT NULL
+    AND JSON.MALPRACTICE_CLAIMAMOUNT IS NOT NULL),
+    
+CTE_BadMalpracticeClaimTypeCode AS (
+    SELECT DISTINCT 
+        P.ProviderCode, 
+        'Bad Malpractice Claim Type Code value of ' || COALESCE(S.MalpracticeClaimTypeCode,'NULL') AS ProblemType, 
+        RN1
+    FROM CTE_swimlane S
+    JOIN Base.Provider P ON P.ProviderId = S.ProviderId
+    LEFT JOIN Base.MalpracticeClaimType MCT ON MCT.MalpracticeClaimTypeCode = S.MalpracticeClaimTypeCode
+    WHERE MCT.MalpracticeClaimTypeId IS NULL
+    
+            UNION ALL
+    
+    SELECT DISTINCT 
+        P.ProviderCode, 
+        'Bad Malpractice Claim Type Code value of ' || COALESCE(S.MalpracticeClaimTypeCode,'NULL') AS ProblemType, 
+        RN1
+    FROM CTE_swimlane S
+    JOIN Base.Provider P ON P.ProviderId = S.ProviderId
+    LEFT JOIN Base.MalpracticeClaimType MCT ON MCT.MalpracticeClaimTypeID = S.MalpracticeClaimTypeID
+    WHERE MCT.MalpracticeClaimTypeId IS NULL	
+    
+            UNION ALL
+    
+    SELECT 
+        S.ProviderCode, 
+        'Bad IncidentDate value: ' || TO_VARCHAR(IncidentDate), 
+        RN1
+    FROM CTE_swimlane S
+    WHERE TRY_CAST(IncidentDate AS DATE) IS NULL AND IncidentDate IS NOT NULL
+    
+            UNION ALL
+    
+    SELECT 
+        S.ProviderCode, 
+        'Bad ReportDate value: ' || TO_VARCHAR(ReportDate), 
+        RN1
+    FROM CTE_swimlane S
+    WHERE TRY_CAST(ReportDate AS DATE) IS NULL AND ReportDate IS NOT NULL
+    
+            UNION ALL
+    
+    SELECT 
+        S.ProviderCode, 
+        'Bad ClaimDate value: ' || TO_VARCHAR(ClaimDate), 
+        RN1
+    FROM CTE_swimlane S
+    WHERE TRY_CAST(ClaimDate AS DATE) IS NULL AND ClaimDate IS NOT NULL
+    
+            UNION ALL
+    
+    SELECT 
+        S.ProviderCode, 
+        'Bad ClosedDate value: ' || TO_VARCHAR(ClosedDate), 
+        RN1
+    FROM CTE_swimlane S
+    WHERE TRY_CAST(ClosedDate AS DATE) IS NULL AND ClosedDate IS NOT NULL
+    
+            UNION ALL
+    
+    SELECT 
+        S.ProviderCode, 
+        'Bad ClaimYear value: ' || TO_VARCHAR(ClaimYear),
+        RN1
+    FROM CTE_swimlane S
+    WHERE TRY_CAST(ClaimYear AS INT) IS NULL AND ClaimYear IS NOT NULL
+),
+CTE_KEEP AS (
+    SELECT 
+        S.ProviderId,
+        S.ProviderLicenseId,
+        S.MalpracticeClaimTypeID,
+        S.ProviderCode,
+        S.MalpracticeClaimTypeCode,
+        S.ClaimNumber,
+        S.ClaimDate,
+        S.ClaimYear,
+        S.ClaimAmount,
+        S.ClaimState,
+        S.MalpracticeClaimRange,
+        S.Complaint,
+        S.IncidentDate,
+        S.ClosedDate,
+        S.ReportDate,
+        S.SourceCode,
+        S.LicenseNumber,
+        S.LastUpdateDate,
+        S.RowRank, 
+        S.RN1
+    FROM CTE_swimlane AS S
+    WHERE (
+        (
+            COALESCE(TRY_CAST(S.IncidentDate AS DATE), '1900-01-01'::DATE) > DATEADD('YEAR', -5, CURRENT_DATE()) OR 
+            COALESCE(TRY_CAST(S.ReportDate AS DATE), '1900-01-01'::DATE) > DATEADD('YEAR', -5, CURRENT_DATE()) OR 
+            COALESCE(TRY_CAST(S.ClaimDate AS DATE), '1900-01-01'::DATE) > DATEADD('YEAR', -5, CURRENT_DATE()) OR 
+            COALESCE(TRY_CAST(S.ClosedDate AS DATE), '1900-01-01'::DATE) > DATEADD('YEAR', -5, CURRENT_DATE())
+        )
+        OR (
+            S.IncidentDate IS NULL AND 
+            S.ReportDate IS NULL AND 
+            S.ClaimDate IS NULL AND 
+            S.ClosedDate IS NULL AND 
+            S.ClaimYear IS NOT NULL AND 
+            TRY_CAST(S.ClaimYear AS INT) > EXTRACT(YEAR FROM DATEADD('YEAR', -5, CURRENT_DATE()))))), 
+CTE_Delete1 AS (
+    SELECT 
+        ProviderId,
+        ProviderLicenseId,
+        MalpracticeClaimTypeID,
+        ProviderCode,
+        MalpracticeClaimTypeCode,
+        ClaimNumber,
+        ClaimDate,
+        ClaimYear,
+        ClaimAmount,
+        ClaimState,
+        MalpracticeClaimRange,
+        Complaint,
+        IncidentDate,
+        ClosedDate,
+        ReportDate,
+        SourceCode,
+        LicenseNumber,
+        LastUpdateDate,
+        RowRank,
+        RN1
+    FROM CTE_Swimlane
+    WHERE RN1 IN (SELECT RN1 FROM CTE_KEEP))
+SELECT 
+    ProviderId,
+    ProviderLicenseId,
+    MalpracticeClaimTypeID,
+    ProviderCode,
+    MalpracticeClaimTypeCode,
+    ClaimNumber,
+    ClaimDate,
+    ClaimYear,
+    ClaimAmount,
+    ClaimState,
+    MalpracticeClaimRange,
+    Complaint,
+    IncidentDate,
+    ClosedDate,
+    ReportDate,
+    SourceCode,
+    LicenseNumber,
+    LastUpdateDate,
+    RowRank,
+    RN1
+FROM CTE_Delete1 AS D
+WHERE D.RN1 NOT IN (SELECT RN1 FROM CTE_BadMalpracticeClaimTypeCode) $$;
+
+
+    -- Insert Statement
+insert_statement := ' INSERT  
+                            (ProviderMalpracticeID,
+                            ProviderID,
+                            ProviderLicenseID,
+                            MalpracticeClaimTypeID,
+                            ClaimNumber,
+                            ClaimDate,
+                            ClaimYear,
+                            ClaimAmount,
+                            ClaimState,
+                            MalpracticeClaimRange,
+                            Complaint,
+                            IncidentDate,
+                            ClosedDate,
+                            ReportDate,
+                            SourceCode,
+                            LicenseNumber,
+                            LastUpdateDate)
+                    VALUES 
+                          ( UUID_STRING(),
+                            source.ProviderID,
+                            source.ProviderLicenseID,
+                            source.MalpracticeClaimTypeID,
+                            source.ClaimNumber,
+                            source.ClaimDate,
+                            source.ClaimYear,
+                            source.ClaimAmount,
+                            source.ClaimState,
+                            source.MalpracticeClaimRange,
+                            source.Complaint,
+                            source.IncidentDate,
+                            source.ClosedDate,
+                            source.ReportDate,
+                            source.SourceCode,
+                            source.LicenseNumber,
+                            source.LastUpdateDate)';
+
+
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------
+
+merge_statement := ' MERGE INTO Base.ProviderMalpractice AS target 
+USING ('||select_statement||') AS source
+ON source.ProviderID = target.ProviderID AND source.ProviderLicenseId = target.ProviderLicenseId AND source.MalpracticeClaimTypeID = target.MalpracticeClaimTypeID
+WHEN MATCHED THEN DELETE 
+WHEN NOT MATCHED THEN'||insert_statement;
+
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+---------------------------------------------------------
+EXECUTE IMMEDIATE merge_statement;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+---------------------------------------------------------
+status := 'Completed successfully';
+RETURN status;
+
+EXCEPTION
+WHEN OTHER THEN
+status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+RETURN status;
+
+END;


### PR DESCRIPTION

-- We can not join with base.providerlicense with the providerlicensecode because in the new json we dont have the prviderlicensecode, but we join it with providerid
-- the first delete to swimlane has been added in the select as a where clause (where JSON.MALPRACTICE_CLAIMAMOUNT IS NOT NULL) and added 
-- We don't migrate the hacky update where we change the claim amount from 100000000 to 99999999.99
-- The delete DELETE #swimlane WHERE RN1 NOT IN (SELECT RN1 FROM CTE_KEEP) has been added as a new cte_delete1 instead 
-- The second delete statement is included in the last select of the select_Statement