### PR TITLE
translation base.officehours

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/OfficeHours/spu_original_OfficeHours.sql
+++ b/migration_original/ODS1Stage/tables/Base/OfficeHours/spu_original_OfficeHours.sql
@@ -1,0 +1,133 @@
+begin
+	if object_id('tempdb..#swimlane') is not null drop table #swimlane
+    select distinct x.OfficeID,
+        convert(uniqueidentifier, convert(varbinary(20), upper(y.DaysOfWeekCode))) as DaysOfWeekID, y.DaysOfWeekCode,
+        y.DoSuppress, y.LastUpdateDate, y.OfficeHoursClosingTime, y.OfficeHoursOpeningTime, 
+        case when y.OfficeIsClosed is null and  y.OfficeHoursOpeningTime is not null then 0 when y.OfficeIsClosed is null then 1 else y.OfficeIsClosed end as OfficeIsClosed, 
+		isnull(y.OfficeIsOpen24Hours, 0) as OfficeIsOpen24Hours, y.SourceCode, x.OfficeCode,
+		row_number() over(partition by x.OfficeID, y.DaysOfWeekCode order by x.CREATE_DATE desc) as RowRank
+    into #swimlane
+    from
+    (
+        select w.* 
+        from
+        (
+            select p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.OFFICE_CODE as OfficeCode, p.OfficeID, 
+                json_query(p.PAYLOAD, '$.EntityJSONString.OfficeHours')  as OfficeJSON
+            from raw.OfficeProfileProcessingDeDup as d with (nolock)
+            inner join raw.OfficeProfileProcessing as p with (nolock) on p.rawOfficeProfileID = d.rawOfficeProfileID
+            where p.PAYLOAD is not null
+        ) as w
+        where w.OfficeJSON is not null
+    ) as x
+    cross apply 
+    (
+        select *
+        from openjson(x.OfficeJSON) with (
+			DaysOfWeekCode varchar(50) '$.DaysOfWeekCode'
+			,DoSuppress bit '$.DoSuppress'
+            ,LastUpdateDate varchar(80) '$.LastUpdateDate'
+			,OfficeCode varchar(50) '$.OfficeCode'
+			,OfficeHoursOpeningTime varchar(80) '$.OpeningTime'
+			,OfficeHoursClosingTime varchar(80) '$.ClosingTime'
+			,OfficeIsClosed bit '$.OfficeIsClosed'
+            ,OfficeIsOpen24Hours bit '$.Open24Hours'
+			,SourceCode varchar(80) '$.SourceCode'
+		)
+    ) as y
+    where isnull(y.DoSuppress, 0) = 0
+	
+	update	#swimlane
+	set		OfficeHoursOpeningTime = null
+	where	OfficeHoursOpeningTime = 'None'
+
+	update	#swimlane
+	set		OfficeHoursClosingTime = null
+	where	OfficeHoursClosingTime = 'None'
+	
+	alter table #swimlane
+	alter column OfficeHoursOpeningTime time
+	alter table #swimlane
+	alter column OfficeHoursClosingTime time
+
+	if @OutputDestination = 'ODS1Stage' begin
+
+		if object_id('tempdb..#ChangedOfficeHours') is not null drop table #ChangedOfficeHours 
+		create table #ChangedOfficeHours (OfficeID uniqueidentifier not null)
+
+		--Delete all OfficeHours who no longer have OfficeHours at all 
+		--We need to output these offices into #ChangedOfficeHours because they won't be upserted later
+		delete oh
+		--select oh.*
+		output deleted.OfficeID into #ChangedOfficeHours(OfficeID)
+		from raw.OfficeProfileProcessingDeDup as p with (nolock)
+		inner join ODS1Stage.Base.OfficeHours as oh on oh.OfficeID = p.OfficeID
+		where not exists (select 1 from #swimlane as s where s.OfficeID = oh.OfficeID)
+
+		if object_id('tempdb..#DeleteOfficeHours') is not null drop table #DeleteOfficeHours
+		create table #DeleteOfficeHours (OfficeID uniqueidentifier not null)
+		
+		--Delete OfficeHours whose DaysOfWeekID changed (case 1. has new DaysOfWeekID)  
+		insert into #DeleteOfficeHours(OfficeID)
+		select distinct o.OfficeID
+		--select *
+		from #swimlane as s
+		inner join ODS1Stage.Base.Office as o on o.OfficeID = s.OfficeID
+		inner join ODS1Stage.Base.DaysOfWeek as dw on dw.DaysOfWeekCode = s.DaysOfWeekCode
+		where not exists (select 1 from ODS1Stage.base.OfficeHours as oh where oh.OfficeID = o.OfficeID and oh.DaysOfWeekID = dw.DaysOfWeekID)
+		 
+		--Delete OfficeHours whose DaysOfWeekID changed (case 2. no longer have the old DaysOfWeekID) 
+		insert into #DeleteOfficeHours(OfficeID)
+		select distinct oh.OfficeID
+		from #swimlane as s
+		inner join ODS1Stage.Base.Office as o on o.OfficeID = s.OfficeID 
+		inner join ods1stage.Base.OfficeHours as oh on oh.OfficeID = o.OfficeID 
+		where not exists
+			(
+				select 1 
+				--select oh2.officeID, oh2.DaysofWeekID
+				from #swimlane as s2 
+				inner join ODS1Stage.Base.Office as o2 on o2.OfficeID = s2.OfficeID
+				inner join ODS1Stage.Base.DaysOfWeek as dw on dw.DaysOfWeekCode = s2.DaysOfWeekCode
+				inner join ods1stage.Base.OfficeHours as oh2 on oh2.OfficeID = s2.OfficeID and oh2.DaysOfWeekID = dw.DaysOfWeekID
+				where oh2.OfficeID = oh.OfficeID and oh2.DaysOfWeekID = oh.DaysOfWeekID
+			)
+			and not exists (select 1 from #DeleteOfficeHours as t where t.OfficeID = oh.OfficeID)
+		
+		delete oh
+		--select oh.*
+		from ODS1Stage.base.OfficeHours as oh
+		where oh.OfficeID in (select OfficeID from #DeleteOfficeHours)
+
+		--Update OfficeHours whose DaysOfWeekID remained same
+		update oh set oh.SourceCode = isnull(s.SourceCode, 'Profisee'), oh.OfficeHoursOpeningTime = s.OfficeHoursOpeningTime, oh.OfficeHoursClosingTime = s.OfficeHoursClosingTime, 
+			oh.OfficeIsClosed = s.OfficeIsClosed, oh.OfficeIsOpen24Hours = s.OfficeIsOpen24Hours, oh.LastUpdateDate = s.LastUpdateDate
+		--select oh.SourceCode, isnull(s.SourceCode, 'Profisee'), oh.OfficeHoursOpeningTime, s.OfficeHoursOpeningTime, oh.OfficeHoursClosingTime, s.OfficeHoursClosingTime, oh.OfficeIsClosed, s.OfficeIsClosed, oh.OfficeIsOpen24Hours, s.OfficeIsOpen24Hours, oh.LastUpdateDate, s.LastUpdateDate
+		output inserted.OfficeID into #ChangedOfficeHours(OfficeID)
+		from #swimlane as s
+		inner join ODS1Stage.Base.Office as o on o.OfficeID = s.OfficeID
+		inner join ODS1Stage.Base.DaysOfWeek as dw on dw.DaysOfWeekCode = s.DaysOfWeekCode
+		inner join ODS1Stage.base.OfficeHours as oh on oh.OfficeID = o.OfficeID and oh.DaysOfWeekID = dw.DaysOfWeekID
+		where (s.OfficeID is not null and s.DaysOfWeekID is not null and s.OfficeIsClosed is not null and s.OfficeIsOpen24Hours is not null and s.RowRank = 1)
+			and (
+				isnull(oh.SourceCode, 'Profisee') != isnull(s.SourceCode, 'Profisee')
+				or isnull(oh.OfficeHoursOpeningTime, '08:00:00.0000000') != isnull(s.OfficeHoursOpeningTime, '08:00:00.0000000')
+				or isnull(oh.OfficeHoursClosingTime, '17:00:00.0000000') != isnull(s.OfficeHoursClosingTime, '17:00:00.0000000')
+				or isnull(oh.OfficeIsClosed, 1) != isnull(s.OfficeIsClosed, 1)
+				or isnull(oh.OfficeIsOpen24Hours, 0) != isnull(s.OfficeIsOpen24Hours, 0)
+			)
+
+		--Insert new records
+		insert into ODS1Stage.Base.OfficeHours (OfficeHoursID, OfficeID, SourceCode, DaysOfWeekID, OfficeHoursOpeningTime, OfficeHoursClosingTime, 
+			OfficeIsClosed, OfficeIsOpen24Hours, LastUpdateDate)
+		output inserted.OfficeID into #ChangedOfficeHours(OfficeID)
+		select distinct newid(), s.OfficeID, isnull(s.SourceCode, 'Profisee'), dw.DaysOfWeekID, s.OfficeHoursOpeningTime, s.OfficeHoursClosingTime, 
+			s.OfficeIsClosed, s.OfficeIsOpen24Hours, isnull(s.LastUpdateDate, getutcdate())
+		-- select count(*)
+		-- select distinct newid(), s.OfficeID, isnull(s.SourceCode, 'Profisee'), dw.DaysOfWeekID, s.OfficeHoursOpeningTime, s.OfficeHoursClosingTime, s.OfficeIsClosed, s.OfficeIsOpen24Hours, isnull(s.LastUpdateDate, getutcdate())
+		from #swimlane as s	
+		inner join ODS1Stage.Base.Office as o on o.OfficeID = s.OfficeID
+		inner join ODS1Stage.Base.DaysOfWeek as dw on dw.DaysOfWeekCode = s.DaysOfWeekCode
+		left join ODS1Stage.Base.OfficeHours as oh on oh.OfficeID = o.OfficeID and oh.DaysOfWeekID = dw.DaysOfWeekID
+		where s.OfficeID is not null and s.DaysOfWeekID is not null and s.OfficeIsClosed is not null and s.OfficeIsOpen24Hours is not null and s.RowRank = 1
+			and oh.OfficeID is null

--- a/migration_original/ODS1Stage/tables/Base/OfficeHours/spu_translated_OfficeHours.sql
+++ b/migration_original/ODS1Stage/tables/Base/OfficeHours/spu_translated_OfficeHours.sql
@@ -1,0 +1,172 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_OFFICEHOURS()
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+    
+-- Base.OfficeHours depends on: 
+--- Raw.VW_OFFICE_PROFILE
+--- Base.Office
+--- Base.DaysOfWeek
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+    select_statement_1 STRING; -- CTE and Select statement for the Merge
+    select_statement_2 STRING; 
+    update_statement STRING; -- Update statement for the Merge
+    update_clause STRING; -- where condition for update
+    insert_statement STRING; -- Insert statement for the Merge
+    merge_statement STRING; -- Merge statement to final table
+    status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    -- no conditionals
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+--- Select Statement
+select_statement_1 := $$ WITH CTE_Swimlane AS (
+SELECT
+	O.OfficeID,
+	DW.DaysOfWeekId,
+	IFNULL(JSON.HOURS_LastUpdateDate, SYSDATE()) AS LastUpdateDate,
+	TO_TIME(JSON.HOURS_ClosingTime) AS OfficeHoursClosingTime, 
+	TO_TIME(JSON.HOURS_OpeningTime) AS OfficeHoursOpeningTime,  
+	case when JSON.HOURS_IsClosed is null and JSON.HOURS_OpeningTime is not null then 0 when JSON.HOURS_IsClosed is null then 1 else JSON.HOURS_IsClosed end as OfficeIsClosed,
+	IFNULL(JSON.HOURS_IsOpen24Hours, 0) as OfficeIsOpen24Hours, 
+	IFNULL( JSON.HOURS_SourceCode , 'Profisee' ) AS SourceCode, 
+	JSON.OfficeCode,
+    row_number() over(partition by O.OfficeID, JSON.HOURS_DaysOfWeekCode order by CREATE_DATE desc) AS RowRank 
+
+FROM RAW.VW_OFFICE_PROFILE AS JSON
+	LEFT JOIN Base.Office AS O ON O.OfficeCode = JSON.OfficeCode
+	LEFT JOIN Base.DaysOfWeek AS DW ON DW.DaysOfWeekCode = 
+JSON.HOURS_DaysOfWeekCode
+WHERE OFFICE_PROFILE IS NOT NULL ),
+
+CTE_NotExists AS (
+select 1
+                from CTE_swimlane as s
+                inner join Base.Office as O on O.OfficeId = S.OfficeId
+                inner join Base.DaysOfWeek as DW on DW.DaysOfWeekID = S.DaysOfWeekId
+                inner join Base.OfficeHours as OH on OH.OfficeId = S.OfficeID and OH.DaysOfWeekID = DW.DaysOfWeekID
+                where OH.OfficeID = O.OfficeID and OH.DaysOfWeekID = DW.DaysOfWeekID
+),
+
+CTE_DeleteOfficeHours AS (
+SELECT DISTINCT
+	O.OfficeID
+FROM CTE_Swimlane AS S
+	INNER JOIN Base.Office AS O ON O.OfficeCode = S.OfficeCode 
+	INNER JOIN Base.DaysOfWeek AS DW ON DW.DaysOfWeekID = S.DaysOfWeekId
+WHERE NOT EXISTS (SELECT * FROM CTE_NotExists)) $$;
+
+select_statement_2 := select_statement_1 || $$ SELECT DISTINCT
+	OfficeID, 
+	SourceCode, 
+	DaysOfWeekID, 
+	OfficeHoursOpeningTime, 
+	OfficeHoursClosingTime,
+	OfficeIsClosed, 
+	OfficeIsOpen24Hours, 
+	LastUpdateDate
+FROM CTE_swimlane
+WHERE 
+	OfficeID IS NOT NULL AND
+	DaysOfWeekID IS NOT NULL AND
+	OfficeIsClosed IS NOT NULL AND
+	OfficeIsOpen24Hours IS NOT NULL AND
+	RowRank = 1  $$;
+
+
+
+--- Update Statement
+update_statement := ' UPDATE
+					SET
+	target.SourceCode = source.SourceCode, 
+	target.OfficeHoursOpeningTime = source.OfficeHoursOpeningTime, 
+	target.OfficeHoursClosingTime = source.OfficeHoursClosingTime, 
+	target.OfficeIsClosed = source.OfficeIsClosed, 
+	target.OfficeIsOpen24Hours = source.OfficeIsOpen24Hours, 
+	target.LastUpdateDate = source.LastUpdateDate';
+                            
+-- Update Clause
+update_clause := $$ target.SourceCode != source.SourceCode
+or IFNULL(target.OfficeHoursOpeningTime, '08:00:00.0000000') != IFNULL(source.OfficeHoursOpeningTime, '08:00:00.0000000')
+or IFNULL(target.OfficeHoursClosingTime, '17:00:00.0000000') != IFNULL(source.OfficeHoursClosingTime, '17:00:00.0000000')
+or IFNULL(target.OfficeIsClosed, 1) != IFNULL(source.OfficeIsClosed, 1)
+or IFNULL(target.OfficeIsOpen24Hours, 0) != IFNULL(source.OfficeIsOpen24Hours, 0)
+                    $$;                        
+        
+--- Insert Statement
+insert_statement := 'INSERT ( 
+    OfficeHoursID, 
+	OfficeID, 
+	SourceCode, 
+	DaysOfWeekID, 
+	OfficeHoursOpeningTime, 
+	OfficeHoursClosingTime,
+	OfficeIsClosed, 
+	OfficeIsOpen24Hours, 
+	LastUpdateDate)
+
+VALUES (
+    UUID_STRING(),
+    source.OfficeID, 
+	source.SourceCode, 
+	source.DaysOfWeekID, 
+	source.OfficeHoursOpeningTime, 
+	source.OfficeHoursClosingTime,
+	source.OfficeIsClosed, 
+	source.OfficeIsOpen24Hours, 
+	source.LastUpdateDate)';
+
+
+    
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+merge_statement := ' MERGE INTO Base.OfficeHours as target USING 
+                   ('||select_statement_2 ||') as source 
+                   ON source.Officeid = target.officeid
+		           WHEN MATCHED AND target.OfficeID IN (' || select_statement_1 || ' SELECT OfficeId FROM CTE_DeleteOfficeHours ) THEN DELETE
+                   WHEN MATCHED AND' || update_clause || 'THEN '||update_statement|| '
+                   WHEN NOT MATCHED THEN '||insert_statement ;
+                   
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+                    
+EXECUTE IMMEDIATE merge_statement;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+
+    
+END;


### PR DESCRIPTION
The DaysOfWeekId has been taken from the base table
The updates of swimlane to the officehoursclosingtime and openingtime are obsolete as now the new json does not have the value None
There is a delete that comes from the DeDup table, since we dont have duplicates in the new version this delete does no longer apply so we dont need to create #changedofficehours 
I had to split the select statement because there is a delete that is done with an intermediary CTE and I can not call it in the query 
