### PR TITLE
Base.partnerentity

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/PartnerToEntity/spu_original_PartnerToEntity.sql
+++ b/migration_original/ODS1Stage/tables/Base/PartnerToEntity/spu_original_PartnerToEntity.sql
@@ -1,0 +1,161 @@
+-- etl.spuMergeProviderOASCustomerProduct
+
+begin
+
+	--OASCustomerProduct for provider URL
+	if object_id('tempdb..#swimlaneURL') is not null drop table #swimlaneURL
+	select distinct pb.ProviderID, x.ProviderCode,
+		left(y.OASCustomerProductCode,charindex('-',y.OASCustomerProductCode)-1) as PartnerCode,
+		y.OASCustomerProductCode,
+		coalesce(y.OASPartnerPrimaryEntityID,pb.NPI) as OASPartnerPrimaryEntityID, y.OASURL,
+		z.ExternalOASPartnerCode,
+		row_number() over(partition by x.ProviderCode, y.OASCustomerProductCode order by x.CREATE_DATE desc) as RowRank
+	into #swimlaneURL
+	from
+	(
+		select w.* 
+		from
+		(
+            select p.CREATE_DATE, p.PROVIDER_CODE as ProviderCode,
+				json_query(p.PAYLOAD, '$.EntityJSONString.OASCustomerProduct') as ProviderJSON
+            from raw.ProviderProfileProcessingDeDup as d with (nolock)
+            inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+			where p.PAYLOAD is not null
+		) as w
+		where w.ProviderJSON is not null
+	) as x
+	cross apply 
+	(
+		select *
+		from openjson(x.ProviderJSON) 
+		with (
+				OASCustomerProductCode varchar(50) '$.CustomerToProductCode', 
+				OASPartnerPrimaryEntityID varchar(50) '$.OASPartnerPrimaryEntityID',
+				OASURL varchar(1000) '$.OASURL',
+				LastUpdateDate datetime '$.LastUpdateDate',
+				ExternalOASPartnerJSON nvarchar(max) '$.ExternalOASPartner' as json
+			)
+	) as y
+	outer apply
+	(
+		select *
+		from openjson(y.ExternalOASPartnerJSON) with (
+		ExternalOASPartnerCode varchar(50) '$.ExternalOASPartnerCode',
+		LastUpdateDate datetime2 '$.LastUpdateDate'
+		)
+	) as z
+	inner join ODS1Stage.Base.Provider pb on pb.ProviderCode = x.ProviderCode
+	where y.OASCustomerProductCode is not null --and y.OASURL is not null -- EGS 11/6/19 removed requirement that OASURL is not null, as some URLs are constructed in a Mid process
+
+	--OASCustomerProduct for provider-office API components
+	if object_id('tempdb..#swimlaneAPI') is not null drop table #swimlaneAPI
+	select x.ProviderCode, pb.ProviderID, y.OfficeCode, ob.OfficeID,
+		left(zz.OASCustomerProductCode,charindex('-',zz.OASCustomerProductCode)-1) as PartnerCode,
+		zz.OASCustomerProductCode, coalesce(zz.OASPartnerPrimaryEntityID,pb.NPI) as OASPartnerPrimaryEntityID, zz.OASPartnerSecondaryEntityID, zz.OASPartnerTertiaryEntityID,
+		row_number() over(partition by x.ProviderCode, y.OfficeCode order by x.CREATE_DATE desc, isnull(zz.OASCustomerProductCode,'') desc) as RowRank
+	into #swimlaneAPI
+	from
+	(
+		select w.* 
+		from
+		(
+			select p.CREATE_DATE, p.PROVIDER_CODE as ProviderCode,
+				json_query(p.PAYLOAD, '$.EntityJSONString.Office') as ProviderOfficeJSON
+            from raw.ProviderProfileProcessingDeDup as d with (nolock)
+            inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+			where p.PAYLOAD is not null
+        ) as w
+		where w.ProviderOfficeJSON is not null
+	) as x
+	cross apply --All provider-offices are needed for a join back to #swimlaneURL for insert into Base.PartnerToEntity for OASURL
+	(
+		select *
+		from openjson(x.ProviderOfficeJSON) 
+			with (
+				LastUpdateDate datetime '$.LastUpdateDate', 
+				OfficeCode varchar(50) '$.OfficeCode', 
+				SourceCode varchar(25) '$.SourceCode',
+				OASCustomerProduct nvarchar(max) '$.OASCustomerProduct' as json
+			)
+	) as y
+    outer apply 
+    (
+        select *
+        from openjson(y.OASCustomerProduct) with (
+				OASCustomerProductCode varchar(50) '$.CustomerToProductCode',
+				OASPartnerPrimaryEntityID varchar(50) '$.OASPartnerPrimaryEntityID',
+				OASPartnerSecondaryEntityID varchar(50) '$.OASPartnerSecondaryEntityID',
+				OASPartnerTertiaryEntityID varchar(50) '$.OASPartnerTertiaryEntityID'
+				)
+    ) as zz
+	inner join ODS1Stage.Base.Provider as pb on pb.ProviderCode = x.ProviderCode
+	inner join ODS1Stage.Base.Office as ob on ob.OfficeCode = y.OfficeCode
+	where zz.OASCustomerProductCode is not null
+	
+	declare @ProviderEntityTypeID uniqueidentifier, @OfficeEntityTypeID uniqueidentifier, @PracticeEntityTypeID uniqueidentifier
+	select @ProviderEntityTypeID = et.EntityTypeID from ODS1Stage.Base.EntityType as et where et.EntityTypeCode = 'PROV'
+	select @OfficeEntityTypeID = et.EntityTypeID from ODS1Stage.Base.EntityType as et where et.EntityTypeCode = 'OFFICE'
+	select @PracticeEntityTypeID = et.EntityTypeID from ODS1Stage.Base.EntityType as et where et.EntityTypeCode = 'PRAC'
+	
+	if object_id('tempdb..#swimlaneURL2') is not null drop table #swimlaneURL2
+	select s.ProviderCode, s.RowRank, s.OASCustomerProductCode, s.OASPartnerPrimaryEntityID, s.PartnerCode, pp.PartnerID, p.ProviderID as PrimaryEntityID, 
+        @ProviderEntityTypeID as PrimaryEntityTypeID, s.OASPartnerPrimaryEntityID as PartnerPrimaryEntityID, s2.OfficeID as SecondaryEntityID, 
+        @OfficeEntityTypeID as SecondaryEntityTypeID, s2.OfficeID as PartnerSecondaryEntityID, s.OASURL, getutcdate() as LastUpdateDate,
+		eop.ExternalOASPartnerID
+    into #swimlaneURL2
+	from #swimlaneURL as s
+	inner join ODS1Stage.Base.Provider as p on s.ProviderCode=p.ProviderCode
+	inner join ODS1Stage.Base.ProviderToOffice as s2 on s2.ProviderID = p.ProviderID  --this join gets all offices for the provider
+	inner join ODS1Stage.Base.Partner pp on s.PartnerCode = pp.PartnerCode
+	left join ODS1Stage.Base.ExternalOASPartner as eop on eop.ExternalOASPartnerCode = s.ExternalOASPartnerCode
+	where s.RowRank = 1 and s.OASPartnerPrimaryEntityID is not null
+
+	if object_id('tempdb..#swimlaneAPI2') is not null drop table #swimlaneAPI2
+	select s.ProviderCode, s.RowRank, s.OASCustomerProductCode, s.OASPartnerPrimaryEntityID, s.PartnerCode, pp.PartnerID, p.ProviderID as PrimaryEntityID, 
+        @ProviderEntityTypeID as PrimaryEntityTypeID, s.OASPartnerPrimaryEntityID as PartnerPrimaryEntityID, 
+		s.OfficeID as SecondaryEntityID, @OfficeEntityTypeID as SecondaryEntityTypeID, coalesce(s.OASPartnerSecondaryEntityID, cast(s.OfficeID as varchar(100))) as PartnerSecondaryEntityID,
+		case when s.OASPartnerTertiaryEntityID is not null then o.PracticeID end as TertiaryEntityID, 
+		case when s.OASPartnerTertiaryEntityID is not null then @PracticeEntityTypeID end as TertiaryEntityTypeID, 
+		s.OASPartnerTertiaryEntityID as PartnerTertiaryEntityID, getutcdate() as LastUpdateDate
+    into #swimlaneAPI2
+	from #swimlaneAPI as s
+	inner join ODS1Stage.Base.Provider p on s.ProviderCode=p.ProviderCode
+	inner join ODS1Stage.Base.Partner pp on s.PartnerCode = pp.PartnerCode
+	inner join ODS1Stage.Base.Office as o with (nolock) on o.OfficeID = s.OfficeID
+	where s.RowRank = 1 and s.OASPartnerPrimaryEntityID is not null
+
+	if @OutputDestination = 'ODS1Stage' begin
+		--Delete Records who don't have any CP
+		delete a
+		from #swimlaneAPI a
+		where not exists (select 1 from #swimlaneAPI as z where OASCustomerProductCode is not null and a.ProviderCode = z.ProviderCode)
+	
+		--Delete all PartnerToEntity for all providers in the raw.ProviderProfileProcessing
+		delete pc
+		--select count(*)
+        from raw.ProviderProfileProcessingDeDup as p with (nolock)
+	    inner join ODS1Stage.Base.Provider p2 on p2.ProviderCode = p.ProviderCode
+		inner join ODS1Stage.Base.PartnerToEntity as pc on pc.PrimaryEntityID = p2.ProviderID
+
+		--select * from ODS1Stage.Base.PartnerToEntity
+		insert into ODS1Stage.Base.PartnerToEntity (PartnerID, PrimaryEntityID, PrimaryEntityTypeID, PartnerPrimaryEntityID, SecondaryEntityID, SecondaryEntityTypeID, PartnerSecondaryEntityID, OASURL, LastUpdateDate, ExternalOASPartnerID)
+        select PartnerID, PrimaryEntityID, PrimaryEntityTypeID, PartnerPrimaryEntityID, SecondaryEntityID, SecondaryEntityTypeID, PartnerSecondaryEntityID, OASURL, LastUpdateDate, ExternalOASPartnerID
+        from #swimlaneURL2
+	
+		--Primary, secondary & tertiary are always provider, office, practice in order
+		insert into ODS1Stage.Base.PartnerToEntity (PartnerID, PrimaryEntityID, PrimaryEntityTypeID, PartnerPrimaryEntityID, SecondaryEntityID, SecondaryEntityTypeID, PartnerSecondaryEntityID, TertiaryEntityID, TertiaryEntityTypeID, PartnerTertiaryEntityID, LastUpdateDate)
+        select PartnerID, PrimaryEntityID, PrimaryEntityTypeID, PartnerPrimaryEntityID, SecondaryEntityID, SecondaryEntityTypeID, PartnerSecondaryEntityID, TertiaryEntityID, TertiaryEntityTypeID, PartnerTertiaryEntityID, LastUpdateDate
+        from #swimlaneAPI2
+	end
+
+
+    -- mid.spuPartnerEntityRefresh
+
+    	DELETE .Base.PartnerToEntity 
+	WHERE	PrimaryEntityId IN (
+				SELECT	DISTINCT PrimaryEntityId
+				FROM	.Base.PartnerToEntity
+				WHERE	OASURL IS NOT NULL 
+			)
+			AND OASURL IS NULL
+

--- a/migration_original/ODS1Stage/tables/Base/PartnerToEntity/spu_translated_PartnerToEntity.sql
+++ b/migration_original/ODS1Stage/tables/Base/PartnerToEntity/spu_translated_PartnerToEntity.sql
@@ -1,0 +1,168 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_PARTNERTOENTITY() 
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+    
+-- Base.PartnerToEntity depends on:
+--- RAW.VW_PROVIDER_PROFILE
+--- Base.Provider
+--- Base.Partner
+--- Base.Office
+--- Base.ProviderToOffice
+--- Base.EntityType
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+    select_statement_1 STRING; -- CTE and Select statement for the insert
+    select_statement_2 STRING;
+    insert_statement_1 STRING; -- Insert statement 
+    insert_statement_2 STRING;
+    status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    -- no conditionals
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+--- Select Statement
+select_statement_1 := $$
+WITH CTE_SwimlaneURL AS (
+    SELECT DISTINCT
+        P.ProviderId,
+        JSON.ProviderCode,
+        LEFT(JSON.OAS_CUSTOMERPRODUCTCODE, POSITION('-' IN JSON.OAS_CUSTOMERPRODUCTCODE) - 1) AS PartnerCode,
+        JSON.OAS_CUSTOMERPRODUCTCODE AS OASCustomerProductCode,
+        JSON.OAS_URL AS OasURL,
+        row_number() over(partition by JSON.ProviderCode, JSON.OAS_CUSTOMERPRODUCTCODE order by CREATE_DATE desc) as RowRank
+    FROM RAW.VW_PROVIDER_PROFILE AS JSON
+    INNER JOIN Base.Provider AS P ON P.ProviderCode = JSON.ProviderCode
+    WHERE PROVIDER_PROFILE IS NOT NULL AND
+        OAS_CUSTOMERPRODUCTCODE IS NOT NULL
+),
+CTE_SwimlaneAPI AS (
+    SELECT 
+        JSON.ProviderCode,
+        P.ProviderId,
+        O.OfficeId,
+        JSON.OFFICE_OFFICECODE AS OfficeCode,
+        SUBSTRING(
+        JSON.OAS_CUSTOMERPRODUCTCODE, 
+        1, POSITION('-' IN JSON.OAS_CUSTOMERPRODUCTCODE) - 1) AS PartnerCode ,
+        JSON.OAS_CUSTOMERPRODUCTCODE AS OasCustomerProductCode,
+        row_number() over(partition by JSON.ProviderCode, JSON.OFFICE_OFFICECODE order by CREATE_DATE desc) as RowRank
+    FROM RAW.VW_PROVIDER_PROFILE AS JSON
+    INNER JOIN Base.Provider AS P ON P.ProviderCode = JSON.ProviderCode
+    INNER JOIN Base.Office AS O ON O.OFFICECODE = JSON.OFFICE_OFFICECODE
+),
+CTE_SwimlaneAPIUpdated AS (
+    select * 
+    from cte_swimlaneapi AS api1
+    where exists (select * from cte_swimlaneapi AS api2 JOIN cte_swimlaneapi AS api1 ON api1.Providercode = api2.ProviderCode AND api2.OASCustomerProductCode IS NOT NULL)
+), 
+CTE_SwimlaneURL2 AS (
+    SELECT
+        UUID_STRING() AS PartnerToEntityId,
+        Par.PartnerId,
+        Prov.ProviderId AS PrimaryEntityId,
+        (select entitytypeid from Base.entitytype where entitytypecode = 'PROV') As PrimaryEntityTypeId,
+        ProvOff.OfficeId AS SecondaryEntityID,
+        (select entitytypeid from Base.entitytype where entitytypecode = 'OFFICE') As SecondaryEntityTypeID,
+        ProvOff.OfficeId AS PartnerSecondaryEntityId,
+        cte.OASUrl,
+        SYSDATE() AS LastUpdateDate
+    FROM CTE_swimlaneUrl AS cte
+    INNER JOIN Base.Partner AS Par ON Par.PartnerCode = cte.PartnerCode
+    INNER JOIN Base.Provider AS Prov ON Prov.ProviderCode = cte.ProviderCode
+    INNER JOIN Base.ProviderToOffice AS ProvOff ON ProvOff.ProviderID = cte.ProviderId
+    WHERE RowRank = 1 
+)$$;
+
+
+select_statement_2 := select_statement_1 || 
+$$, CTE_SwimlaneAPI2 AS (
+    SELECT
+        UUID_STRING() AS PartnerToEntityId,
+        Par.PartnerId,
+        Prov.ProviderId AS PrimaryEntityId,
+        (select entitytypeid from Base.entitytype where entitytypecode = 'PROV') As PrimaryEntityTypeId,
+        cte.OfficeId AS SecondaryEntityID,
+        (select entitytypeid from Base.entitytype where entitytypecode = 'OFFICE') As SecondaryEntityTypeID,
+        Off.PracticeId AS TertiaryEntityId,
+        (select entitytypeid from Base.entitytype where entitytypecode = 'PRAC') As TertiaryEntityTypeID,
+        SYSDATE() AS LastUpdateDate
+    FROM CTE_SwimlaneAPIUpdated AS cte
+    INNER JOIN Base.Partner AS Par ON Par.PartnerCode = cte.PartnerCode
+    INNER JOIN Base.Provider AS Prov ON Prov.ProviderCode = cte.ProviderCode
+    INNER JOIN Base.Office AS Off ON Off.OfficeId = cte.OfficeID
+    WHERE RowRank = 1
+)
+select * from cte_swimlaneapi2$$;
+
+
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+insert_statement_1 := ' INSERT INTO Base.PartnerToEntity 
+                            (PartnerToEntityId,
+                            PartnerID, 
+                            PrimaryEntityID, 
+                            PrimaryEntityTypeID, 
+                            SecondaryEntityID, 
+                            SecondaryEntityTypeID, 
+                            PartnerSecondaryEntityId,
+                            OASURL, 
+                            LastUpdateDate) ' 
+                            ||select_statement_1|| 'SELECT * FROM CTE_SwimlaneURL2';
+                    
+
+insert_statement_2 := ' INSERT INTO Base.PartnerToEntity 
+                            (PartnerToEntityId,
+                            PartnerID, 
+                            PrimaryEntityID, 
+                            PrimaryEntityTypeID, 
+                            SecondaryEntityID, 
+                            SecondaryEntityTypeID,  
+                            TertiaryEntityID, 
+                            TertiaryEntityTypeID, 
+                            LastUpdateDate) ' ||select_statement_2;                    
+                   
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE insert_statement_1 ;
+EXECUTE IMMEDIATE insert_statement_2 ;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '.f SQL State: ' || SQLSTATE;
+          RETURN status;
+
+
+    
+END;

--- a/migration_original/ODS1Stage/tables/Base/PartnerToEntity/spu_translated_PartnerToEntity.sql
+++ b/migration_original/ODS1Stage/tables/Base/PartnerToEntity/spu_translated_PartnerToEntity.sql
@@ -118,8 +118,11 @@ select * from cte_swimlaneapi2$$;
 --------- 4. Actions (Inserts and Updates) --------------
 ---------------------------------------------------------  
 
-insert_statement_1 := ' INSERT INTO Base.PartnerToEntity 
-                            (PartnerToEntityId,
+insert_statement_1 := ' MERGE INTO Base.PartnerToEntity as target USING 
+                   ('||select_statement_1 ||' SELECT * FROM CTE_swimlaneURL2) as source 
+                   ON target.PartnerToEntityId = source.PartnerToEntityId AND target.PartnerId = source.PartnerId
+                   WHEN NOT MATCHED THEN 
+                    INSERT (PartnerToEntityId,
                             PartnerID, 
                             PrimaryEntityID, 
                             PrimaryEntityTypeID, 
@@ -127,12 +130,23 @@ insert_statement_1 := ' INSERT INTO Base.PartnerToEntity
                             SecondaryEntityTypeID, 
                             PartnerSecondaryEntityId,
                             OASURL, 
-                            LastUpdateDate) ' 
-                            ||select_statement_1|| 'SELECT * FROM CTE_SwimlaneURL2';
-                    
+                            LastUpdateDate)
+                    VALUES (source.PartnerToEntityId,
+                            source.PartnerID, 
+                            source.PrimaryEntityID, 
+                            source.PrimaryEntityTypeID, 
+                            source.SecondaryEntityID, 
+                            source.SecondaryEntityTypeID, 
+                            source.PartnerSecondaryEntityId,
+                            source.OASURL, 
+                            source.LastUpdateDate)';
 
-insert_statement_2 := ' INSERT INTO Base.PartnerToEntity 
-                            (PartnerToEntityId,
+                    
+insert_statement_2 := ' MERGE INTO Base.PartnerToEntity as target USING 
+                   ('||select_statement_2 ||') as source 
+                   ON target.PartnerToEntityId = source.PartnerToEntityId AND target.PartnerId = source.PartnerId
+                   WHEN NOT MATCHED THEN 
+                    INSERT (PartnerToEntityId,
                             PartnerID, 
                             PrimaryEntityID, 
                             PrimaryEntityTypeID, 
@@ -140,8 +154,18 @@ insert_statement_2 := ' INSERT INTO Base.PartnerToEntity
                             SecondaryEntityTypeID,  
                             TertiaryEntityID, 
                             TertiaryEntityTypeID, 
-                            LastUpdateDate) ' ||select_statement_2;                    
-                   
+                            LastUpdateDate)
+                    VALUES (source.PartnerToEntityId,
+                            source.PartnerID, 
+                            source.PrimaryEntityID, 
+                            source.PrimaryEntityTypeID, 
+                            source.SecondaryEntityID, 
+                            source.SecondaryEntityTypeID, 
+                            source.TertiaryEntityID,
+                            source.TertiaryEntityTypeID, 
+                            source.LastUpdateDate)';
+                    
+ 
 ---------------------------------------------------------
 ------------------- 5. Execution ------------------------
 --------------------------------------------------------- 


### PR DESCRIPTION
-- The new JSON is named OAS instead of OASCustomerProduct
-- The column from the swimlaneurl OASPartnerPrimaryEntityID can not be replicated because it does not come in the json anymore and there is no base table to take it from
-- ExternalOASPartnerCode does not come in the json anymore and can not be included in the swimlaneurl select
-- OASCustomerProductCode does not exist so i can not call it in the select of the swimlaneapi, same for OASPartnerPrimaryEntityID, OASPartnerSecondaryEntityID, OASPartnerTertiaryEntityID
-- The second delete to the table does not apply because it is based on a de dup table which is empty in the new MDM format as there are no dups
-- I needed to split the select statement in different chuncks to be able to call them separatedly
-- PartnertoEntityID is not created anywhere and its the main id for this table, i created it with a uuid_string
-- the delete to swimlaneapi has been included in a new cte called cte_swimlaneapiupdated