### PR TITLE
base.entitytomedicalterm

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/EntityToMedicalTerm/spu_original_EntityToMedicalTerm.sql
+++ b/migration_original/ODS1Stage/tables/Base/EntityToMedicalTerm/spu_original_EntityToMedicalTerm.sql
@@ -1,0 +1,281 @@
+-- etl.spumergeprovidercondition
+
+begin
+	if object_id('tempdb..#swimlane') is not null drop table #swimlane
+	create table #swimlane (
+		ProviderID uniqueidentifier, 
+		ProviderCode varchar(50),
+		EntityID uniqueidentifier, 
+		MedicalTermID uniqueidentifier, 
+		ConditionCode varchar(50),
+		DecileRank int, 
+		IsPreview bit, 
+		LastUpdateDate datetime, 
+		MedicalTermRank int, 
+		NationalRankingA int, 
+		NationalRankingB int, 
+		PatientCount int, 
+		PatientCountIsFew bit, 
+		Searchable int, 
+		SourceCode varchar(50), 
+		SourceSearch tinyint, 
+		RowRank int,
+		primary key (ProviderID, MedicalTermID)
+	)
+		
+	insert into	#swimlane (ProviderID, ProviderCode, EntityID, MedicalTermID, ConditionCode, DecileRank, IsPreview, LastUpdateDate, MedicalTermRank, NationalRankingA, NationalRankingB,PatientCount, PatientCountIsFew, Searchable, SourceCode, SourceSearch, RowRank)
+	select		ProviderID, ProviderCode, EntityID, MedicalTermID, ConditionCode, DecileRank, IsPreview, LastUpdateDate, MedicalTermRank, NationalRankingA, NationalRankingB,PatientCount, PatientCountIsFew, Searchable, SourceCode, SourceSearch, RowRank
+	from(
+		select	case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end as ProviderID, 
+				case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end as EntityID, 
+				x.ProviderCode, y.MedicalTermID, y.ConditionCode, y.DecileRank, y.IsPreview, isnull(y.LastUpdateDate, getutcdate()) as LastUpdateDate, y.MedicalTermRank, y.NationalRankingA, y.NationalRankingB, y.PatientCount, y.PatientCountIsFew, y.Searchable, isnull(y.SourceCode, 'Profisee') as SourceCode, isnull(y.SourceSearch, 0) as SourceSearch, 
+				row_number() over(partition by (case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end), y.ConditionCode order by x.CREATE_DATE desc) as RowRank
+		from(
+			select	w.* 
+			from(
+				select		p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.PROVIDER_CODE as ProviderCode, p.ProviderID, p.Condition_Payload as ProviderJSON
+				from		raw.ProviderProfileProcessingDeDup as d with (nolock)
+				inner join	raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+				where		isnull(p.HasCondition,0) = 1 
+							and p.Condition_Payload is not null
+			) w
+			where	w.ProviderJSON is not null
+		) x
+		cross apply(
+			select	*, convert(uniqueidentifier, convert(varbinary(20), z.ConditionCode)) as MedicalTermID
+			from(
+				select	*
+				from	openjson(x.ProviderJSON) with (
+							DecileRank int '$.DecileRank'
+							,IsPreview bit '$.IsPreview'
+							,LastUpdateDate datetime '$.LastUpdateDate'
+							,ConditionCode varchar(50) '$.ConditionCode'
+							,MedicalTermRank int '$.MedicalTermRank'
+							,NationalRankingA int '$.NationalRankingA'
+							,NationalRankingB int '$.NationalRankingB'
+							,PatientCount int '$.PatientCount'
+							,PatientCountIsFew bit '$.PatientCountIsFew'
+							,Searchable int '$.Searchable'
+							,SourceCode varchar(25) '$.SourceCode'
+							,SourceSearch tinyint '$.SourceSearch')
+			) z
+		) y
+		inner join	ODS1Stage.Base.MedicalTerm as mt 
+					on mt.MedicalTermID = y.MedicalTermID
+		inner join	ODS1Stage.Base.MedicalTermType as mtt 
+					on mtt.MedicalTermTypeID = mt.MedicalTermTypeID 
+					and mtt.MedicalTermTypeCode = 'Condition'
+        left join 	ODS1Stage.Base.Provider as pID 
+					on pID.ProviderCode = x.ProviderCode
+		where		y.ConditionCode is not null
+	) a
+	where		a.RowRank=1
+	order by	ProviderID, MedicalTermID
+
+	if @OutputDestination = 'ODS1Stage' begin
+		declare @EntityTypeID uniqueidentifier = (select EntityTypeID from ODS1Stage.Base.EntityType where EntityTypeCode = 'PROV')	
+		declare @medicaltermtypeID uniqueidentifier = (select MedicalTermTypeID from ODS1Stage.Base.MedicalTermType where MedicalTermTypeCode='Condition')
+		
+		--Records to Delete (where the provider loses all DCPs)
+		if object_id('tempdb..#DeleteAll') is not null drop table #DeleteAll
+		select		EntityToMedicalTermID
+		into		#DeleteAll
+		from		raw.ProviderProfileProcessingDeDup as d with (nolock)
+		inner join	raw.ProviderProfileProcessing as p with (nolock) 
+					on p.rawProviderProfileID=d.rawProviderProfileID
+        inner join  ODS1Stage.Base.Provider as p2 on p2.ProviderCode = p.PROVIDER_CODE
+	    inner join	ODS1Stage.Base.EntityToMedicalTerm pc with (nolock) 
+					on pc.EntityID = p2.ProviderID
+	    inner join	ODS1Stage.Base.MedicalTerm as mt with (nolock) 
+					on mt.MedicalTermID = pc.MedicalTermID 
+					and mt.MedicalTermTypeID = @medicaltermtypeID
+		where		isnull(p.HasCondition,0) = 0
+	
+		delete ODS1Stage.Base.EntityToMedicalTerm where EntityToMedicalTermID in (select EntityToMedicalTermID from #DeleteAll)
+	
+		--Records to Delete (where the provider loses some DCPs)
+		if object_id('tempdb..#DeleteSome') is not null drop table #DeleteSome
+		select	    EntityToMedicalTermID
+		into		#DeleteSome
+	    from		raw.ProviderProfileProcessingDeDup as d with (nolock)
+		inner join	raw.ProviderProfileProcessing as p with (nolock) 
+					on p.rawProviderProfileID=d.rawProviderProfileID
+        inner join  ODS1Stage.Base.Provider as p2 on p2.ProviderCode = p.PROVIDER_CODE
+	    inner join	ODS1Stage.Base.EntityToMedicalTerm pc with (nolock) 
+					on pc.EntityID = p2.ProviderID
+	    inner join	ODS1Stage.Base.MedicalTerm as mt with (nolock) 
+					on mt.MedicalTermID = pc.MedicalTermID 
+					and mt.MedicalTermTypeID = @medicaltermtypeID
+		left join	#swimlane T
+					on T.ProviderID = pc.EntityID
+					and T.MedicalTermID = pc.MedicalTermID
+		where		isnull(p.HasCondition,0) = 1
+					and T.ProviderID is null
+
+		delete ODS1Stage.Base.EntityToMedicalTerm where EntityToMedicalTermID in (select EntityToMedicalTermID from #DeleteSome)
+	
+		--Records to Update (Provider already has DCPs)
+		update dest
+		set dest.PatientCountIsFew = src.PatientCountIsFew, dest.LastUpdateDate = src.LastUpdateDate, dest.IsPreview = src.IsPreview, 
+				dest.NationalRankingA = src.NationalRankingA, dest.PatientCount = src.PatientCount, dest.SourceSearch = src.SourceSearch, 
+				dest.NationalRankingB = src.NationalRankingB, /*dest.EntityToMedicalTermID = newid(),*/ dest.SourceCode = src.SourceCode, 
+				/*dest.EntityTypeID = @EntityTypeID,*/ dest.MedicalTermRank = src.MedicalTermRank
+		--select count(*)
+		from #swimlane src
+	    inner join ODS1Stage.Base.EntityToMedicalTerm dest on dest.EntityID = src.ProviderID and dest.MedicalTermID = src.MedicalTermID
+		where (isnull(dest.PatientCountIsFew,0) <> isnull(src.PatientCountIsFew,0) or /*dest.LastUpdateDate <> src.LastUpdateDate or*/ isnull(dest.IsPreview,0) <> isnull(src.IsPreview,0) or 
+				isnull(dest.NationalRankingA,0) <> isnull(src.NationalRankingA,0) or isnull(dest.PatientCount,0) <> isnull(src.PatientCount,0) or isnull(dest.SourceSearch,0) <> isnull(src.SourceSearch,0) or 
+				isnull(dest.NationalRankingB,0) <> isnull(src.NationalRankingB,0) or /*dest.SourceCode <> src.SourceCode or*/ isnull(dest.MedicalTermRank,0) <> isnull(src.MedicalTermRank,0))
+		--46 min, 137,137,120 without the WHERE clause	
+		--2 min to run the entire statement, 20 rows affected		
+	
+		--Records to Insert (Provider has New DCPs)
+		select s.EntityID, s.MedicalTermID, @EntityTypeID as EntityTypeID, s.MedicalTermRank, 
+	        s.SourceCode, s.Searchable, s.LastUpdateDate, s.PatientCount, s.DecileRank, s.PatientCountIsFew, s.SourceSearch, 
+			s.IsPreview, s.NationalRankingA, s.NationalRankingB
+		into #tmp2
+		from #swimlane s
+		where not exists (select 1 from ODS1Stage.Base.EntityToMedicalTerm as pc with (nolock) where pc.EntityID=s.ProviderID and pc.MedicalTermID=s.MedicalTermID)
+		order by EntityID, MedicalTermID
+
+		insert into ODS1Stage.Base.EntityToMedicalTerm (EntityID, MedicalTermID, EntityTypeID, MedicalTermRank, 
+	        SourceCode, Searchable, LastUpdateDate, PatientCount, DecileRank, PatientCountIsFew, SourceSearch, 
+	        IsPreview, NationalRankingA, NationalRankingB)
+		select EntityID, MedicalTermID, EntityTypeID, MedicalTermRank, 
+	        SourceCode, Searchable, LastUpdateDate, PatientCount, DecileRank, PatientCountIsFew, SourceSearch, 
+	        IsPreview, NationalRankingA, NationalRankingB
+		from #tmp2
+	end
+
+    
+-- etl.spumergeproviderprocedure
+
+begin
+	if object_id('tempdb..#swimlane') is not null drop table #swimlane
+	create table #swimlane (
+		ProviderID uniqueidentifier, 
+		ProviderCode varchar(50),
+		EntityID uniqueidentifier, 
+		MedicalTermID uniqueidentifier, 
+		ProcedureCode varchar(50),
+		DecileRank int, 
+		IsPreview bit, 
+		LastUpdateDate datetime, 
+		MedicalTermRank int, 
+		NationalRankingA int, 
+		NationalRankingB int, 
+		PatientCount int, 
+		PatientCountIsFew bit, 
+		Searchable int, 
+		SourceCode varchar(50), 
+		SourceSearch tinyint, 
+		RowRank int,
+		primary key (ProviderID, MedicalTermID)
+		)
+
+	insert into #swimlane (ProviderID, ProviderCode, EntityID, MedicalTermID, ProcedureCode, DecileRank, IsPreview, LastUpdateDate, MedicalTermRank, NationalRankingA, NationalRankingB,
+			PatientCount, PatientCountIsFew, Searchable, SourceCode, SourceSearch, RowRank)
+	select ProviderID, ProviderCode, EntityID, MedicalTermID, ProcedureCode, DecileRank, IsPreview, LastUpdateDate, MedicalTermRank, NationalRankingA, NationalRankingB,
+			PatientCount, PatientCountIsFew, Searchable, SourceCode, SourceSearch, RowRank 
+	from (
+		select distinct case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end as ProviderID, 
+			x.ProviderCode, pID.ProviderID as EntityID, 
+			y.MedicalTermID, y.ProcedureCode, y.DecileRank, y.IsPreview, isnull(y.LastUpdateDate, getutcdate()) as LastUpdateDate, y.MedicalTermRank, 
+			y.NationalRankingA, y.NationalRankingB, --y.NationalRankingBCalc, 
+			y.PatientCount, y.PatientCountIsFew, y.Searchable, isnull(y.SourceCode, 'Profisee') as SourceCode, isnull(y.SourceSearch, 0) as SourceSearch, 
+			row_number() over(partition by (case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end), y.ProcedureCode order by x.CREATE_DATE desc) as RowRank
+		from
+		(
+			select w.*
+			from
+			(
+				select p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.PROVIDER_CODE as ProviderCode, p.ProviderID, p.Procedure_Payload as ProviderJSON
+				from raw.ProviderProfileProcessingDeDup as d with (nolock)
+				inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+				where isnull(p.HasProcedure,0) = 1 and p.Procedure_Payload is not null
+			) as w
+			where w.ProviderJSON is not null
+		) as x
+		left join ODS1Stage.Base.Provider as pID on pID.ProviderCode = x.ProviderCode
+		cross apply 
+		(
+			select *, convert(uniqueidentifier, convert(varbinary(20), z.ProcedureCode)) as MedicalTermID
+			from 
+			(
+				select *
+				from openjson(x.ProviderJSON) with (DecileRank int '$.DecileRank',  
+				IsPreview bit '$.IsPreview', LastUpdateDate datetime '$.LastUpdateDate', ProcedureCode varchar(50) '$.ProcedureCode', 
+				MedicalTermRank int '$.MedicalTermRank', 
+				NationalRankingA int '$.NationalRankingA', NationalRankingB int '$.NationalRankingB',
+				PatientCount int '$.PatientCount', PatientCountIsFew bit '$.PatientCountIsFew', Searchable int '$.Searchable', 
+				SourceCode varchar(25) '$.SourceCode', SourceSearch tinyint '$.SourceSearch')
+			) as z
+		) as y
+		join ODS1Stage.Base.MedicalTerm as mt on mt.MedicalTermID = y.MedicalTermID
+		join ODS1Stage.Base.MedicalTermType as mtt on mtt.MedicalTermTypeID = mt.MedicalTermTypeID 
+			and mtt.MedicalTermTypeCode = 'Procedure'
+		where y.ProcedureCode is not null
+	) a
+	where RowRank=1
+	order by ProviderID, MedicalTermID
+
+	if @OutputDestination = 'ODS1Stage' begin
+		declare @EntityTypeID uniqueidentifier
+	    select @EntityTypeID = EntityTypeID from ODS1Stage.Base.EntityType where EntityTypeCode = 'PROV'
+		
+		declare @MedicalTermTypeID uniqueidentifier = (select MedicalTermTypeID from ODS1Stage.Base.MedicalTermType where MedicalTermTypeCode='Procedure')
+		
+		--Records to Delete (where the provider loses all DCPs)
+		delete pc
+		--select count(*)
+		from raw.ProviderProfileProcessingDeDup as d with (nolock)
+		inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID=d.rawProviderProfileID
+        inner join ODS1Stage.Base.Provider as p2 on p2.ProviderCode = p.PROVIDER_CODE
+	    inner join ODS1Stage.Base.EntityToMedicalTerm pc with (nolock) on pc.EntityID = p2.ProviderID
+	    inner join ODS1Stage.Base.MedicalTerm as mt with (nolock) on mt.MedicalTermID = pc.MedicalTermID and mt.MedicalTermTypeID = @MedicalTermTypeID
+		where isnull(p.HasProcedure,0)=0
+	
+		--Records to Delete (where the provider loses some DCPs)
+		delete pc
+		--declare @MedicalTermTypeID uniqueidentifier = (select MedicalTermTypeID from ODS1Stage.Base.MedicalTermType where MedicalTermTypeCode='Procedure');select count(*)
+		from raw.ProviderProfileProcessingDeDup as d with (nolock)
+		inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID=d.rawProviderProfileID
+        inner join ODS1Stage.Base.Provider as p2 on p2.ProviderCode = d.ProviderCode
+	    inner join ODS1Stage.Base.EntityToMedicalTerm pc with (nolock) on pc.EntityID = p2.ProviderID
+	    inner join ODS1Stage.Base.MedicalTerm as mt with (nolock) on mt.MedicalTermID = pc.MedicalTermID and mt.MedicalTermTypeID = @MedicalTermTypeID
+		where isnull(p.HasProcedure,0)=1
+		and not exists (select 1 from #swimlane s where pc.EntityID=s.ProviderID and pc.MedicalTermID=s.MedicalTermID)
+	
+		--Records to Update (Provider already has DCPs)
+		update dest
+		set dest.PatientCountIsFew = src.PatientCountIsFew, dest.LastUpdateDate = src.LastUpdateDate, dest.IsPreview = src.IsPreview, 
+				dest.NationalRankingA = src.NationalRankingA, dest.PatientCount = src.PatientCount, dest.SourceSearch = src.SourceSearch, 
+				dest.NationalRankingB = src.NationalRankingB, /*dest.EntityToMedicalTermID = newid(),*/ dest.SourceCode = src.SourceCode, 
+				/*dest.EntityTypeID = @EntityTypeID,*/ dest.MedicalTermRank = src.MedicalTermRank
+		--select count(*)
+		from #swimlane src
+	    inner join ODS1Stage.Base.EntityToMedicalTerm dest on dest.EntityID = src.ProviderID and dest.MedicalTermID = src.MedicalTermID
+		where (isnull(dest.PatientCountIsFew,0) <> isnull(src.PatientCountIsFew,0) or /*dest.LastUpdateDate <> src.LastUpdateDate or*/ isnull(dest.IsPreview,0) <> isnull(src.IsPreview,0) or 
+				isnull(dest.NationalRankingA,0) <> isnull(src.NationalRankingA,0) or isnull(dest.PatientCount,0) <> isnull(src.PatientCount,0) or isnull(dest.SourceSearch,0) <> isnull(src.SourceSearch,0) or 
+				isnull(dest.NationalRankingB,0) <> isnull(src.NationalRankingB,0) or /*dest.SourceCode <> src.SourceCode or*/ isnull(dest.MedicalTermRank,0) <> isnull(src.MedicalTermRank,0))
+	
+		--Records to Insert (Provider has New DCPs)
+        --declare @EntityTypeID uniqueidentifier; select @EntityTypeID = EntityTypeID from ODS1Stage.Base.EntityType where EntityTypeCode = 'PROV'
+		select s.EntityID, s.MedicalTermID, @EntityTypeID as EntityTypeID, s.MedicalTermRank, 
+	        s.SourceCode, s.Searchable, s.LastUpdateDate, s.PatientCount, s.DecileRank, s.PatientCountIsFew, s.SourceSearch, 
+			s.IsPreview, s.NationalRankingA, s.NationalRankingB
+		into #tmp2
+		from #swimlane s
+		where not exists (select 1 from ODS1Stage.Base.EntityToMedicalTerm as pc with (nolock) where pc.EntityID=s.ProviderID and pc.MedicalTermID=s.MedicalTermID)
+		order by EntityID, MedicalTermID
+	
+		insert into ODS1Stage.Base.EntityToMedicalTerm (EntityID, MedicalTermID, EntityTypeID, MedicalTermRank, 
+	        SourceCode, Searchable, LastUpdateDate, PatientCount, DecileRank, PatientCountIsFew, SourceSearch, 
+	        IsPreview, NationalRankingA, NationalRankingB)
+		select distinct S.EntityID, S.MedicalTermID, S.EntityTypeID, S.MedicalTermRank, 
+	        S.SourceCode, S.Searchable, S.LastUpdateDate, S.PatientCount, S.DecileRank, S.PatientCountIsFew, S.SourceSearch, 
+	        S.IsPreview, S.NationalRankingA, S.NationalRankingB
+		from #tmp2 S
+		left join ODS1Stage.Base.EntityToMedicalTerm T on T.EntityID = S.EntityID and T.EntityTypeID = S.EntityTypeID and T.MedicalTermID = S.MedicalTermID
+		where	T.EntityToMedicalTermID is null
+	end

--- a/migration_original/ODS1Stage/tables/Base/EntityToMedicalTerm/spu_translated_EntityToMedicalTerm.sql
+++ b/migration_original/ODS1Stage/tables/Base/EntityToMedicalTerm/spu_translated_EntityToMedicalTerm.sql
@@ -24,11 +24,11 @@ DECLARE
 
     select_statement_1 STRING;
     delete_statement_1 STRING;
-    update_statement_1 STRING;
-    insert_statement_1 STRING;
+    merge_statement_1 STRING;
+    merge_statement_2 STRING;
     select_statement_2 STRING;
-    update_statement_2 STRING;
-    insert_statement_2 STRING;
+    merge_statement_3 STRING;
+    merge_statement_4 STRING;
     status STRING; -- Status monitoring
    
 ---------------------------------------------------------
@@ -172,7 +172,7 @@ delete_statement_1 := 'DELETE FROM Base.EntityToMedicalTerm
                 (' || select_statement_1 || 'SELECT EntityToMedicalTermID FROM CTE_DeleteSome)';
 
 
-update_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+merge_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
                    ('||select_statement_1 ||' SELECT * FROM CTE_swimlane ) as source 
                    ON target.EntityID = source.EntityId AND target.MedicalTermID = source.MedicalTermID
                    WHEN MATCHED AND 
@@ -190,7 +190,7 @@ update_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING
                                 target.NationalRankingB = source.NationalRankingB, 
                                 target.SourceCode = source.SourceCode';
 
-insert_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+merge_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
                    ('||select_statement_1 ||' SELECT * FROM CTE_Tmp2) as source 
                    ON target.EntityID = source.EntityID AND target.MedicalTermID = source.MedicalTermID
                    WHEN NOT MATCHED THEN 
@@ -215,7 +215,7 @@ insert_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING
                                 
 
 
-update_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+merge_statement_3 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
                    ('||select_statement_2 ||' SELECT * FROM CTE_swimlane )   as source 
                    ON target.EntityID = source.EntityId AND target.MedicalTermID = source.MedicalTermID
                    WHEN MATCHED AND 
@@ -231,7 +231,7 @@ update_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING
                             target.NationalRankingB = source.NationalRankingB,
                             target.SourceCode = source.SourceCode';
 
-insert_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+merge_statement_4 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
                    ('||select_statement_2 ||' SELECT * FROM CTE_Tmp2) as source 
                    ON target.EntityID = source.EntityID AND target.MedicalTermID = source.MedicalTermID
                    WHEN NOT MATCHED THEN 
@@ -260,10 +260,10 @@ insert_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING
 --------------------------------------------------------- 
 
 EXECUTE IMMEDIATE delete_statement_1 ;
-EXECUTE IMMEDIATE update_statement_1 ;
-EXECUTE IMMEDIATE insert_statement_1 ;
-EXECUTE IMMEDIATE update_statement_2 ;
-EXECUTE IMMEDIATE insert_statement_2 ;
+EXECUTE IMMEDIATE merge_statement_1 ;
+EXECUTE IMMEDIATE merge_statement_2 ;
+EXECUTE IMMEDIATE merge_statement_3 ;
+EXECUTE IMMEDIATE merge_statement_4 ;
 
 ---------------------------------------------------------
 --------------- 6. Status monitoring --------------------

--- a/migration_original/ODS1Stage/tables/Base/EntityToMedicalTerm/spu_translated_EntityToMedicalTerm.sql
+++ b/migration_original/ODS1Stage/tables/Base/EntityToMedicalTerm/spu_translated_EntityToMedicalTerm.sql
@@ -1,0 +1,284 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_ENTITYTOMEDICALTERM() 
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+    
+
+-- Base.EntityToMedicalTerm depends on:
+--- Raw.VW_PROVIDER_PROFILE
+--- Raw.ProviderProfileProcessing
+--- Base.Provider
+--- Base.EntityToMedicalTerm
+--- Base.MedicalTerm
+--- Base.EntityType
+--- Base.MedicalTermType
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+    select_statement_1 STRING;
+    delete_statement_1 STRING;
+    update_statement_1 STRING;
+    insert_statement_1 STRING;
+    select_statement_2 STRING;
+    update_statement_2 STRING;
+    insert_statement_2 STRING;
+    status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    -- no conditionals
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+--- Select Statement
+
+select_statement_1 := $$ WITH CTE_Swimlane AS (
+    SELECT
+        P.ProviderId,
+        JSON.ProviderCode,
+        P.ProviderId AS EntityId,
+        MT.MedicalTermId,
+        -- ConditionCode
+        -- DecileRank
+        -- IsPreview
+        JSON.MEDICALPROCEDURE_LASTUPDATEDATE AS LastUpdateDate,
+        -- MedicalTermRank
+        JSON.MEDICALPROCEDURE_NATIONALRANKINGA AS NationalRankingA,
+        JSON.MEDICALPROCEDURE_NATIONALRANKINGB AS NationalRankingB,
+        JSON.MEDICALPROCEDURE_PATIENTCOUNT AS PatientCount,
+        JSON.MEDICALPROCEDURE_PATIENTCOUNTISFEW AS PatientCountIsFew,
+        -- Searchable
+        JSON.MEDICALPROCEDURE_SOURCECODE AS SourceCode
+        -- SourceSearch
+    FROM
+        RAW.VW_PROVIDER_PROFILE AS JSON
+        LEFT JOIN Base.Provider AS P ON P.ProviderCode = JSON.ProviderCode
+        LEFT JOIN Base.EntityToMedicalTerm AS ETMT ON ETMT.EntityId = P.ProviderId
+        INNER JOIN Base.MedicalTerm AS MT ON MT.MedicalTermID = ETMT.MedicalTermID
+        INNER JOIN Base.MedicalTermType AS MTT ON MTT.MedicalTermTypeId = MT.MedicalTermTypeId AND MTT.MedicalTermTypeCode = 'Condition'
+    WHERE 
+        PROVIDER_PROFILE IS NOT NULL 
+    QUALIFY row_number() over(partition by ProviderId order by CREATE_DATE desc) = 1
+),
+
+CTE_DeleteAll AS (
+    SELECT DISTINCT
+        EntityToMedicalTermId
+    FROM Raw.VW_PROVIDER_PROFILE AS Process 
+        INNER JOIN Base.Provider AS P ON P.ProviderCode = Process.ProviderCode
+        INNER JOIN Base.EntityToMedicalTerm AS ETMT ON ETMT.EntityId = P.ProviderId
+        INNER JOIN Base.MedicalTerm AS MT ON MT.MedicalTermID = ETMT.MedicalTermID AND MT.MedicalTermTypeId = (SELECT MedicalTermTypeId FROM Base.MedicalTermType WHERE MedicalTermTypeCode = 'Condition' )
+),
+
+CTE_DeleteSome AS (
+    SELECT DISTINCT
+        EntityToMedicalTermId
+    FROM Raw.VW_PROVIDER_PROFILE AS Process
+        INNER JOIN Base.Provider AS P ON P.ProviderCode = Process.ProviderCode
+        INNER JOIN Base.EntityToMedicalTerm AS ETMT ON ETMT.EntityId = P.ProviderId
+        INNER JOIN Base.MedicalTerm AS MT ON MT.MedicalTermID = ETMT.MedicalTermID AND MT.MedicalTermTypeId = (SELECT MedicalTermTypeId FROM Base.MedicalTermType WHERE MedicalTermTypeCode = 'Condition' )
+        LEFT JOIN CTE_swimlane AS S ON S.ProviderID = ETMT.EntityId AND S.MedicalTermID = MT.MedicalTermID
+    WHERE S.ProviderId IS NULL
+),
+CTE_Tmp2 AS (
+    SELECT
+        s.EntityID, 
+        s.MedicalTermID, 
+        (select EntityTypeID from Base.EntityType where EntityTypeCode = 'PROV') as EntityTypeID,  
+	    s.SourceCode, 
+        s.LastUpdateDate, 
+        s.PatientCount, 
+        s.PatientCountIsFew, 
+        s.NationalRankingA, 
+        s.NationalRankingB
+    FROM CTE_Swimlane AS S 
+    WHERE NOT EXISTS (
+        select 1 
+        from Base.EntityToMedicalTerm as ETMT 
+            left join CTE_Swimlane AS S ON S.EntityId = ETMT.EntityId
+        where ETMT.EntityID=S.ProviderID and
+              ETMT.MedicalTermID=s.MedicalTermID) ) $$;
+
+
+select_statement_2 := $$ WITH CTE_Swimlane AS (
+    SELECT
+        P.ProviderId,
+        JSON.ProviderCode,
+        P.ProviderId AS EntityId,
+        MT.MedicalTermId,
+        JSON.MEDICALPROCEDURE_MEDICALPROCEDURECODE AS ProcedureCode,
+        -- DecileRank
+        -- IsPreview
+        IFNULL(JSON.MEDICALPROCEDURE_LASTUPDATEDATE, SYSDATE()) AS LastUpdateDate,
+        -- MedicalTermRank
+        JSON.MEDICALPROCEDURE_NATIONALRANKINGA AS NationalRankingA,
+        JSON.MEDICALPROCEDURE_NATIONALRANKINGB AS NationalRankingB,
+        JSON.MEDICALPROCEDURE_PATIENTCOUNT AS PatientCount,
+        JSON.MEDICALPROCEDURE_PATIENTCOUNTISFEW AS PatientCountIsFew,
+        -- Searchable
+        IFNULL(JSON.MEDICALPROCEDURE_SOURCECODE, 'Profisee') AS SourceCode
+        -- SourceSearch
+    FROM
+        RAW.VW_PROVIDER_PROFILE AS JSON
+        LEFT JOIN Base.Provider AS P ON P.ProviderCode = JSON.ProviderCode
+        LEFT JOIN Base.EntityToMedicalTerm AS ETMT ON ETMT.EntityId = P.ProviderId
+        INNER JOIN Base.MedicalTerm AS MT ON MT.MedicalTermID = ETMT.MedicalTermID
+        INNER JOIN Base.MedicalTermType AS MTT ON MTT.MedicalTermTypeId = MT.MedicalTermTypeId AND MTT.MedicalTermTypeCode = 'Procedure'
+    WHERE 
+        PROVIDER_PROFILE IS NOT NULL 
+        AND JSON.MEDICALPROCEDURE_MEDICALPROCEDURECODE IS NOT NULL
+    QUALIFY row_number() over(partition by ProviderId, JSON.MEDICALPROCEDURE_MEDICALPROCEDURECODE order by CREATE_DATE desc) = 1
+),
+CTE_Tmp2 AS (
+    SELECT
+        s.EntityID, 
+        s.MedicalTermID, 
+        (select EntityTypeID from Base.EntityType where EntityTypeCode = 'PROV') as EntityTypeID,  
+	    s.SourceCode, 
+        s.LastUpdateDate, 
+        s.PatientCount, 
+        s.PatientCountIsFew, 
+        s.NationalRankingA, 
+        s.NationalRankingB
+    FROM CTE_Swimlane AS S 
+    WHERE NOT EXISTS (
+        select 1 
+        from Base.EntityToMedicalTerm as ETMT 
+            left join CTE_Swimlane AS S ON S.EntityId = ETMT.EntityId
+        where ETMT.EntityID=S.ProviderID and
+              ETMT.MedicalTermID=s.MedicalTermID)) $$;
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+delete_statement_1 := 'DELETE FROM Base.EntityToMedicalTerm 
+            WHERE EntityToMedicalTermID IN 
+                (' || select_statement_1 || 'SELECT EntityToMedicalTermID FROM CTE_DeleteAll)
+            OR EntityToMedicalTermID IN 
+                (' || select_statement_1 || 'SELECT EntityToMedicalTermID FROM CTE_DeleteSome)';
+
+
+update_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+                   ('||select_statement_1 ||' SELECT * FROM CTE_swimlane ) as source 
+                   ON target.EntityID = source.EntityId AND target.MedicalTermID = source.MedicalTermID
+                   WHEN MATCHED AND 
+                                    IFNULL(target.PatientCountIsFew,0) <> IFNULL(source.PatientCountIsFew,0) 
+                                    OR IFNULL(target.NationalRankingA,0) <> IFNULL(source.NationalRankingA,0) 
+                                    OR IFNULL(target.PatientCount,0) <> IFNULL(source.PatientCount,0) 
+                                    OR IFNULL(target.NationalRankingB,0) <> IFNULL(source.NationalRankingB,0)
+                   THEN 
+                    UPDATE 
+                            SET 
+                                target.PatientCountIsFew = source.PatientCountIsFew, 
+                                target.LastUpdateDate = source.LastUpdateDate, 
+                                target.NationalRankingA = source.NationalRankingA, 
+                                target.PatientCount = source.PatientCount, 
+                                target.NationalRankingB = source.NationalRankingB, 
+                                target.SourceCode = source.SourceCode';
+
+insert_statement_1 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+                   ('||select_statement_1 ||' SELECT * FROM CTE_Tmp2) as source 
+                   ON target.EntityID = source.EntityID AND target.MedicalTermID = source.MedicalTermID
+                   WHEN NOT MATCHED THEN 
+                    INSERT (EntityID, 
+                            MedicalTermID, 
+                            EntityTypeID, 
+                            SourceCode, 
+                            LastUpdateDate, 
+                            PatientCount, 
+                            PatientCountIsFew,
+                            NationalRankingA, 
+                            NationalRankingB)
+                    VALUES (source.EntityID, 
+                            source.MedicalTermID, 
+                            source.EntityTypeID,  
+                            source.SourceCode,
+                            source.LastUpdateDate, 
+                            source.PatientCount,
+                            source.PatientCountIsFew,  
+                            source.NationalRankingA, 
+                            source.NationalRankingB)';
+                                
+
+
+update_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+                   ('||select_statement_2 ||' SELECT * FROM CTE_swimlane )   as source 
+                   ON target.EntityID = source.EntityId AND target.MedicalTermID = source.MedicalTermID
+                   WHEN MATCHED AND 
+                                    IFNULL(target.PatientCountIsFew,0) <> IFNULL(source.PatientCountIsFew,0) 
+    OR IFNULL(target.NationalRankingA,0) <> IFNULL(source.NationalRankingA,0)
+    OR IFNULL(target.PatientCount,0) <> IFNULL(source.PatientCount,0)
+    OR IFNULL(target.NationalRankingB,0) <> IFNULL(source.NationalRankingB,0)
+                   THEN UPDATE SET 
+                            target.PatientCountIsFew = source.PatientCountIsFew,
+                            target.LastUpdateDate = source.LastUpdateDate,
+                            target.NationalRankingA = source.NationalRankingA,
+                            target.PatientCount = source.PatientCount,
+                            target.NationalRankingB = source.NationalRankingB,
+                            target.SourceCode = source.SourceCode';
+
+insert_statement_2 := ' MERGE INTO Base.EntityToMedicalTerm as target USING 
+                   ('||select_statement_2 ||' SELECT * FROM CTE_Tmp2) as source 
+                   ON target.EntityID = source.EntityID AND target.MedicalTermID = source.MedicalTermID
+                   WHEN NOT MATCHED THEN 
+                    INSERT (EntityID, 
+                            MedicalTermID, 
+                            EntityTypeID,  
+                            SourceCode,
+                            LastUpdateDate, 
+                            PatientCount,
+                            PatientCountIsFew,  
+                            NationalRankingA, 
+                            NationalRankingB)
+                    VALUES (source.EntityID, 
+                            source.MedicalTermID, 
+                            source.EntityTypeID,  
+                            source.SourceCode,
+                            source.LastUpdateDate, 
+                            source.PatientCount,
+                            source.PatientCountIsFew,  
+                            source.NationalRankingA, 
+                            source.NationalRankingB)';
+                            
+                 
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE delete_statement_1 ;
+EXECUTE IMMEDIATE update_statement_1 ;
+EXECUTE IMMEDIATE insert_statement_1 ;
+EXECUTE IMMEDIATE update_statement_2 ;
+EXECUTE IMMEDIATE insert_statement_2 ;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+
+    
+END;


### PR DESCRIPTION

-- In the new JSON this info is inside the key MEDICALPROCEDURE
-- EntityId is providerid
-- To get the medicaltermid i have no entitycode to join on with the base.medicalterm so need to join it first with base.entitytomedicalterm and then base.medicalterm
-- Conditioncode, ispreview, decilerank, searchable and sourcesearch do no longer exist in the new json
-- the two deletes to base.entitytomedicalterm have been merged in a single delete statement
-- The two selects are really similar but one is for condition and the other procedure
-- The delete statement to the table depends on dedup table so we dont need to do it
-- the condition of the insert of the entitytomedicaltermid is null was added in the select instead