### PR TITLE
base.providertomapcustomerproduct

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProviderToMAPCustomerProduct/spu_original_ProviderToMAPCustomerProduct.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToMAPCustomerProduct/spu_original_ProviderToMAPCustomerProduct.sql
@@ -1,0 +1,181 @@
+-- etl.spumergeprovidermapcustomerproduct
+begin
+    --Get all MAP Provider-CustomerProduct info for the provider
+	if object_id('tempdb..#ProviderCustomerProduct') is not null drop table #ProviderCustomerProduct
+    select distinct case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end as ProviderID, 
+		x.ProviderReltioEntityID, x.ProviderCode,
+        left(y.CustomerProductCode,charindex('-',y.CustomerProductCode)-1) as ClientCode,
+        substring(y.CustomerProductCode,(charindex('-',y.CustomerProductCode)+1),len(y.CustomerProductCode)) as ProductCode,
+        y.CustomerProductCode as ClientToProductCode, 
+        row_number() over(partition by (case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end), y.CustomerProductCode order by x.CREATE_DATE desc) as RowRank
+    into #ProviderCustomerProduct
+    from
+    (
+        select w.* 
+        from
+        (
+            select p.CREATE_DATE, p.RELTIO_ID as ProviderReltioEntityID, p.PROVIDER_CODE as ProviderCode, p.ProviderID, 
+                json_query(p.PAYLOAD, '$.EntityJSONString.CustomerProduct') as ProviderJSON
+            from raw.ProviderProfileProcessingDeDup as d with (nolock)
+            inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+            where p.PAYLOAD is not null
+        ) as w
+        where w.ProviderJSON is not null
+    ) as x
+    left join ODS1Stage.Base.Provider pID on pID.providercode = x.ProviderCode
+    cross apply 
+    (
+        select *
+        from openjson(x.ProviderJSON) with (
+            CustomerProductCode varchar(50) '$.CustomerProductCode')
+    ) as y
+    join ODS1Stage.Base.ClientToProduct as cp on cp.ClientToProductCode = y.CustomerProductCode
+    where y.CustomerProductCode is not null
+		
+    --Get all MAP Provider-Office-CustomerProduct info for the provider
+	if object_id('tempdb..#ProviderOfficeCustomerProduct') is not null drop table #ProviderOfficeCustomerProduct
+    select distinct case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end ProviderID
+		,x.ProviderReltioEntityID
+		,x.ProviderCode
+        ,left(y.CustomerProductCode,charindex('-',y.CustomerProductCode)-1) as ClientCode
+        ,substring(y.CustomerProductCode,(charindex('-',y.CustomerProductCode)+1),len(y.CustomerProductCode)) as ProductCode
+        ,y.CustomerProductCode as ClientToProductCode
+		,y.OfficeCode
+		,y.OfficeReltioEntityID
+		,y.TrackingNumber
+		,y.DisplayPhoneNumber
+		,y.ProviderOfficeRank
+		,y.DisplayPartnerCode
+		,y.RingToNumber
+		,y.RingToNumberType
+		,row_number() over(partition by (case when pID.ProviderID is not null then pID.ProviderID else x.ProviderID end), y.OfficeCode, y.DisplayPartnerCode order by case when y.TrackingNumber is not null then 0 else 1 end, x.CREATE_DATE desc) as RowRank
+    into #ProviderOfficeCustomerProduct
+    from
+    (
+        select w.* 
+        from
+        (
+            select p.CREATE_DATE, p.RELTIO_ID as ProviderReltioEntityID, p.PROVIDER_CODE as ProviderCode, p.ProviderID, 
+                json_query(p.PAYLOAD, '$.EntityJSONString.Office') as ProviderJSON
+            from raw.ProviderProfileProcessingDeDup as d with (nolock)
+            inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+            where p.PAYLOAD is not null
+        ) as w
+        where w.ProviderJSON is not null
+    ) as x
+    left join ODS1Stage.Base.Provider pID on pID.providercode = x.ProviderCode
+    cross apply 
+    (
+        select *
+        from openjson(x.ProviderJSON) with (
+            ProviderOfficeRank varchar(50) '$."CalculatedOfficeRank"',
+            OfficeCode varchar(50) '$."OfficeCode"',
+            OfficeReltioEntityID varchar(50) '$."ReltioEntityID"',
+            CustomerProductCode varchar(50) '$.CustomerProductCode',
+            RingToNumber varchar(50) '$.DestinationPhoneNumber',
+            TrackingNumber varchar(50) '$.TrackingPhoneNumber',
+			DisplayPhoneNumber varchar(50) '$.DisplayPhoneNumber',
+			DisplayPartnerCode varchar(50) '$.DisplayPartnerCode',
+			RingToNumberType varchar(50) '$.DestinationPhoneNumberTypeCode'
+		)
+    ) as y
+    inner join ODS1Stage.Base.ClientToProduct as cp on cp.ClientToProductCode = y.CustomerProductCode
+	inner join ODS1Stage.Base.SyndicationPartner as sp on sp.SyndicationPartnerCode = y.DisplayPartnerCode
+	inner join ODS1Stage.Base.DestinationPhoneNumberType as dp on dp.DestinationPhoneNumberTypeCode = y.RingToNumberType
+    where y.CustomerProductCode is not null
+
+    create index ixTem on #ProviderOfficeCustomerProduct (ProviderID, ClientToProductCode)
+	
+	update	T
+	set		TrackingNumber = '('+stuff(stuff(REPLACE(TrackingNumber,'-',''),4,0,') '),9,0,'-')
+	--SELECT	'('+STUFF(STUFF(REPLACE(TrackingNumber,'-',''),4,0,') '),9,0,'-'),TrackingNumber
+	from	#ProviderOfficeCustomerProduct T
+	where	TrackingNumber is not null
+			and isnumeric(REPLACE(TrackingNumber,'-','')) = 1
+
+
+	IF OBJECT_ID('tempdb..#ClientLevelPhones') IS NOT NULL DROP TABLE #ClientLevelPhones
+	SELECT		DISTINCT CPE.ClientProductToEntityID, CP.ClientToProductId, CP.ClientToProductCode, PT.PhoneTypeCode, P.PhoneNumber
+	INTO		#ClientLevelPhones
+	FROM		ODS1Stage.Base.ClientProductEntityToPhone CPEP
+	INNER JOIN	ODS1Stage.Base.ClientProductToEntity CPE ON CPE.ClientProductToEntityID = CPEP.ClientProductToEntityID
+	INNER JOIN	ODS1Stage.Base.EntityType ET ON ET.EntityTypeID = CPE.EntityTypeID
+	INNER JOIN	ODS1Stage.Base.ClientToProduct CP ON CP.ClientToProductId = CPE.ClientToProductId
+	INNER JOIN	ODS1Stage.Base.PhoneType PT ON PT.PhoneTypeID = CPEP.PhoneTypeID
+	INNER JOIN	ODS1Stage.Base.Phone P On P.PhoneID = CPEP.PhoneID
+	INNER JOIN	#ProviderCustomerProduct T ON T.ClientToProductCode = CP.ClientToProductCode
+	WHERE		ET.EntityTypeCode = 'CLPROD'
+
+	if @OutputDestination = 'ODS1Stage' begin
+        --Delete all ProviderToMAPCustomerProduct records for all parents in p.ProviderProfileProcessing_EGS
+
+        delete pc
+        --select pc.*
+        from raw.ProviderProfileProcessingDeDup as d with (nolock)
+        inner join raw.ProviderProfileProcessing as p with (nolock) on p.rawProviderProfileID = d.rawProviderProfileID
+        inner join ODS1Stage.Base.Provider as p2 on p2.ProviderCode = p.PROVIDER_CODE
+        inner join ODS1Stage.Base.ProviderToMAPCustomerProduct as pc on pc.ProviderID = p2.ProviderID
+	
+	    --select * from ODS1Stage.Base.ProviderToMAPCustomerProduct 
+        --Insert all ProviderToMAPCustomerProduct records
+        insert into ODS1Stage.Base.ProviderToMAPCustomerProduct (ProviderID, OfficeID, ClientToProductID, PhoneXML, RingToNumberType, DisplayPartnerCode, InsertedBy, DisplayPhoneNumber, RingToNumber, TrackingNumber)
+        select pcp.ProviderID, o.OfficeID, cp.ClientToProductID, 
+            (
+			    select ph, phTyp
+			    from(
+				    select pocp.DisplayPhoneNumber as ph, 'PTODS' as phTyp
+				    union
+				    select CLP.PhoneNumber as ph, CLP.PhoneTypeCode as phTyp
+				    from #ClientLevelPhones CLP where CLP.ClientToProductCode = pcp.ClientToProductCode
+			    )X
+                for xml raw('phone'), elements, type
+            ) as PhoneXML
+			,pocp.RingToNumberType
+		    ,pocp.DisplayPartnerCode
+			,case when pocp.TrackingNumber is not null then 'CallCap' else 'No Tracking #' end as InsertedBy
+			,pocp.DisplayPhoneNumber 
+			,pocp.RingToNumber
+			,pocp.TrackingNumber
+        --select pocp.*
+		from #ProviderCustomerProduct pcp
+        inner join #ProviderOfficeCustomerProduct as pocp on pocp.ProviderID = pcp.ProviderID and pocp.ClientToProductCode = pcp.ClientToProductCode	
+        inner join ODS1Stage.Base.Office as o on o.OfficeCode = pocp.OfficeCode
+        inner join ODS1Stage.Base.ClientToProduct as cp on cp.ClientToProductCode = pcp.ClientToProductCode
+        where pcp.RowRank=1 and pocp.RowRank = 1
+			    AND pcp.ProductCode = 'MAP'
+		
+		
+	    /*Add Missing*/
+	    insert into ODS1Stage.Base.ProviderToMAPCustomerProduct (ProviderID, OfficeID, ClientToProductID, PhoneXML, DisplayPartnerCode)
+	    SELECT P.ProviderId, O.OfficeID, lCP.ClientToProductID,
+			    (
+				    SELECT ph, phTyp
+				    FROM(
+					    select PH.PhoneNumber as ph, 'PTODS' as phTyp
+				    )X
+				    for xml raw('phone'), elements, type
+			    ) as PhoneXML
+			    ,'HG' AS DisplayPartnerCode
+	    FROM	ODS1Stage.Base.Provider P
+	    INNER JOIN	ODS1Stage.Base.ProviderToOffice PO on PO.ProviderId = P.ProviderID
+	    INNER JOIN	ODS1Stage.Base.OfficeToPhone OPH ON OPH.OfficeID = PO.OfficeID 
+	    INNER JOIN	ODS1Stage.Base.Phone PH ON PH.PhoneId = OPH.PhoneID
+	    INNER JOIN  ODS1Stage.Base.PhoneType PT ON PT.PhoneTypeId = OPH.PhoneTypeId AND PT.PhoneTypeCode = 'SERVICE'
+	    INNER JOIN	ODS1Stage.Base.Office O ON O.OfficeId = PO.OfficeID
+	    INNER JOIN	ODS1Stage.Base.OfficeToAddress OA on OA.OfficeId = O.OfficeId
+	    INNER JOIN	ODS1Stage.Base.Address A on A.AddressId = OA.AddressId
+	    INNER JOIN	ODS1Stage.Base.CityStatePostalCode CSPC on CSPC.CityStatePostalCodeID = A.CityStatePostalCodeID
+	    INNER JOIN	ODS1Stage.Base.ClientProductToEntity lCPE ON lCPE.EntityId = P.ProviderId
+	    INNER JOIN	ODS1Stage.Base.EntityType dE ON dE.EntityTypeId = lCPE.EntityTypeID
+	    INNER JOIN	ODS1Stage.Base.ClientToProduct lCP ON lCP.ClientToProductID = lCPE.ClientToProductID
+	    INNER JOIN	ODS1Stage.Base.Client dC ON lCP.ClientID = dC.ClientID
+	    INNER JOIN	ODS1Stage.Base.Product dP ON dP.ProductId = lCP.ProductID
+	    LEFT JOIN	ODS1Stage.Base.ProviderToMAPCustomerProduct T ON T.ProviderId = P.ProviderId AND T.OfficeID = O.OfficeID AND T.DisplayPartnerCode = 'HG'
+	    WHERE		dP.ProductCode = 'MAP'
+				    AND T.ProviderToMAPCustomerProductID IS NULL
+
+	    DELETE pmcp
+        --select *
+        from ods1stage.base.ProviderToMAPCustomerProduct  as pmcp
+	    where len(cast(phonexml as varchar(max))) <= len('<phone><phTyp>PTODS</phTyp></phone>')
+	end

--- a/migration_original/ODS1Stage/tables/Base/ProviderToMAPCustomerProduct/spu_translated_ProviderToMAPCustomerProduct.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToMAPCustomerProduct/spu_translated_ProviderToMAPCustomerProduct.sql
@@ -1,0 +1,277 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_PROVIDERTOMAPCUSTOMERPRODUCT() 
+    RETURNS STRING
+    LANGUAGE SQL
+    EXECUTE AS CALLER
+    AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+    
+-- Base.ProviderToMAPCustomerProduct depends on:
+--- RAW.VW_PROVIDER_PROFILE
+--- Base.Provider
+--- Base.ClientToProduct
+--- Base.ClientProductToEntity
+--- Base.EntityType
+--- Base.PhoneType 
+--- Base.Phone
+--- Base.Office
+--- Base.ProviderToOffice
+--- Base.OfficeToPhone
+--- Base.OfficeToAddress
+--- Base.Address
+--- Base.CityStatePostalCode
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+    select_statement STRING; -- CTE and Select statement for the insert
+    insert_statement_1 STRING; -- Insert statement 
+    insert_statement_2 STRING;
+    status STRING; -- Status monitoring
+   
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+   
+BEGIN
+    -- no conditionals
+
+
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------     
+
+--- Select Statement
+select_statement := $$ WITH CTE_ProviderCustomerProduct AS (
+    SELECT DISTINCT
+        P.ProviderId,
+        CP.ClientToProductId,
+        -- ProviderReltioEntityId
+        JSON.ProviderCode,
+        SUBSTRING(JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE, 1,  POSITION('-' IN JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE) - 1 ) AS ClientCode,
+        SUBSTR(JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE, POSITION('-' IN JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE) + 1, LENGTH(JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE)
+) AS ProductCode,
+        JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE AS ClientToProductCode,
+        row_number() over(partition by P.ProviderId, JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE order by CREATE_DATE desc) as RowRank
+    FROM RAW.VW_PROVIDER_PROFILE AS JSON
+        LEFT JOIN Base.Provider AS P ON P.ProviderCode = JSON.ProviderCode
+        INNER JOIN Base.ClientToProduct AS CP ON CP.ClientToProductCode = JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE
+    WHERE PROVIDER_PROFILE IS NOT NULL
+          AND JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE IS NOT NULL),
+
+CTE_ProviderOfficeCustomerProduct AS (
+    SELECT DISTINCT
+        P.ProviderId,
+        -- ProviderReltioEntityId
+        JSON.ProviderCode,
+        SUBSTRING(JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE, 1,  POSITION('-' IN JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE) - 1 ) AS ClientCode,
+        SUBSTR(JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE, POSITION('-' IN JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE) + 1, LENGTH(JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE)
+) AS ProductCode,
+        JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE AS ClientToProductCode,
+        JSON.OFFICE_OFFICECODE AS OfficeCode,
+        -- OfficeReltioEntityID
+        -- TrackingNumber
+        JSON.OFFICE_PHONENUMBER AS DisplayPhoneNumber,
+        JSON.OFFICE_OFFICERANK AS ProviderOfficeRank,
+        -- DisplayPartnerCode
+        -- RingToNumber
+        -- RingToNumberType
+        row_number() over(partition by ProviderID, OFFICE_OFFICECODE order by CREATE_DATE desc) as RowRank
+    FROM RAW.VW_PROVIDER_PROFILE AS JSON
+        LEFT JOIN Base.Provider AS P ON P.ProviderCode = JSON.ProviderCode
+        INNER JOIN Base.ClientToProduct AS CP ON CP.ClientToProductCode = JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE
+    WHERE PROVIDER_PROFILE IS NOT NULL
+          AND JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE IS NOT NULL
+),
+CTE_ClientLevelPhones AS (
+    SELECT DISTINCT 
+        CPE.ClientProductToEntityID, 
+        CP.ClientToProductId, 
+        CP.ClientToProductCode, 
+        PT.PhoneTypeCode, 
+        P.PhoneNumber
+    FROM Base.ClientProductEntityToPhone AS CPEP
+    	INNER JOIN	Base.ClientProductToEntity AS CPE ON CPE.ClientProductToEntityID = CPEP.ClientProductToEntityID
+    	INNER JOIN	Base.EntityType AS ET ON ET.EntityTypeID = CPE.EntityTypeID
+    	INNER JOIN	Base.ClientToProduct AS CP ON CP.ClientToProductId = CPE.ClientToProductId
+    	INNER JOIN	Base.PhoneType AS PT ON PT.PhoneTypeID = CPEP.PhoneTypeID
+    	INNER JOIN	Base.Phone AS P On P.PhoneID = CPEP.PhoneID
+    	INNER JOIN	CTE_ProviderCustomerProduct AS cte ON cte.ClientToProductCode = CP.ClientToProductCode
+	WHERE ET.EntityTypeCode = 'CLPROD'
+),
+
+CTE_Phone1 AS (
+    SELECT 
+        pocp.ProviderId,
+        pocp.DisplayPhoneNumber AS ph, 
+        'PTODS' AS phTyp
+    FROM CTE_ProviderOfficeCustomerProduct AS pocp 
+    UNION ALL
+    SELECT 
+        pcp.ProviderId,
+        CLP.PhoneNumber AS ph, 
+        CLP.PhoneTypeCode AS phTyp
+    FROM CTE_ClientLevelPhones AS CLP 
+    LEFT JOIN CTE_ProviderCustomerProduct AS pcp ON pcp.ClientToProductId = clp.ClientToProductId
+    WHERE CLP.ClientToProductCode = pcp.ClientToProductCode
+),
+
+CTE_PhoneXML1 AS (
+    SELECT
+        providerId,
+        utils.p_json_to_xml(
+            ARRAY_AGG('{ '||
+IFF(ph IS NOT NULL, '"ph":' || '"' || ph || '"' || ',', '') ||
+IFF(phTyp IS NOT NULL, '"phTyp":' || '"' || phTyp || '"', '')
+||' }')::VARCHAR,
+                                    '',
+                                    'phone'
+                                ) AS phoneXML
+    FROM CTE_Phone1
+    GROUP BY ProviderId
+        
+),
+
+CTE_insert_1 AS (
+    SELECT 
+        pcp.ProviderID, 
+        o.OfficeID, 
+        cp.ClientToProductID, 
+        TO_VARIANT(XML.PhoneXML) AS PhoneXML,
+        -- RingToNumberType,
+        -- DisplayPartnerCode,
+        -- InsertedBy,
+        pocp.DisplayPhoneNumber, 
+        -- RingToNumber,
+        -- TrackingNumber
+    FROM CTE_ProviderCustomerProduct AS pcp 
+        INNER JOIN CTE_ProviderOfficeCustomerProduct AS pocp ON pocp.ProviderID = pcp.ProviderID AND pocp.ClientToProductCode = pcp.ClientToProductCode 
+        INNER JOIN Base.Office AS o ON o.OfficeCode = pocp.OfficeCode
+        INNER JOIN Base.ClientToProduct AS cp ON cp.ClientToProductCode = pcp.ClientToProductCode
+        INNER JOIN CTE_PhoneXML1 AS XML ON XML.ProviderId = pocp.ProviderId
+    WHERE 
+        pcp.RowRank = 1 
+        AND pocp.RowRank = 1
+        AND pcp.ProductCode = 'MAP'
+        AND LENGTH(XML.PhoneXML) >= LENGTH('<phone><phTyp>PTODS</phTyp></phone>')
+),
+CTE_Phone2 AS (
+    SELECT 
+        OPH.OfficeId,
+        PH.PhoneNumber as ph, 
+        'PTODS' as phTyp
+    FROM Base.Phone AS PH
+        LEFT JOIN Base.OfficeToPhone AS OPH ON PH.PhoneId = OPH.PhoneId
+),
+
+CTE_PhoneXML2 AS (
+        SELECT
+        OfficeId,
+        utils.p_json_to_xml(
+            ARRAY_AGG('{ '||
+IFF(ph IS NOT NULL, '"ph":' || '"' || ph || '"' || ',', '') ||
+IFF(phTyp IS NOT NULL, '"phTyp":' || '"' || phTyp || '"', '')
+||' }')::VARCHAR,
+                                    '',
+                                    'phone'
+                                ) AS phoneXML
+    FROM CTE_Phone2
+    GROUP BY OfficeId
+),
+
+CTE_Insert_2 AS (
+    SELECT 
+        P.ProviderId, 
+        O.OfficeID, 
+        lCP.ClientToProductID,
+		TO_VARIANT(XML.PhoneXML) AS PhoneXML,
+		'HG' AS DisplayPartnerCode
+	    FROM	Base.Provider P
+    	    INNER JOIN	Base.ProviderToOffice PO on PO.ProviderId = P.ProviderID
+    	    INNER JOIN	Base.OfficeToPhone OPH ON OPH.OfficeID = PO.OfficeID 
+    	    INNER JOIN	Base.Phone PH ON PH.PhoneId = OPH.PhoneID
+    	    INNER JOIN  Base.PhoneType PT ON PT.PhoneTypeId = OPH.PhoneTypeId AND PT.PhoneTypeCode = 'SERVICE'
+    	    INNER JOIN	Base.Office O ON O.OfficeId = PO.OfficeID
+    	    INNER JOIN	Base.OfficeToAddress OA on OA.OfficeId = O.OfficeId
+    	    INNER JOIN	Base.Address A on A.AddressId = OA.AddressId
+    	    INNER JOIN	Base.CityStatePostalCode CSPC on CSPC.CityStatePostalCodeID = A.CityStatePostalCodeID
+    	    INNER JOIN	Base.ClientProductToEntity lCPE ON lCPE.EntityId = P.ProviderId
+    	    INNER JOIN	Base.EntityType dE ON dE.EntityTypeId = lCPE.EntityTypeID
+    	    INNER JOIN	Base.ClientToProduct lCP ON lCP.ClientToProductID = lCPE.ClientToProductID
+    	    INNER JOIN	Base.Client dC ON lCP.ClientID = dC.ClientID
+    	    INNER JOIN	Base.Product dP ON dP.ProductId = lCP.ProductID
+            INNER JOIN CTE_PhoneXML2 AS XML ON XML.OfficeId = P.ProviderId
+	    WHERE		dP.ProductCode = 'MAP'
+                    AND LENGTH(XML.PhoneXML) >= LENGTH('<phone><phTyp>PTODS</phTyp></phone>')
+) $$;
+
+
+
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+insert_statement_1 := ' MERGE INTO Base.ProviderToMapCustomerProduct as target USING 
+                   ('||select_statement ||' SELECT * FROM CTE_insert_1) as source 
+                   ON target.ProviderId = source.ProviderId AND target.OfficeId = source.OfficeId
+                   WHEN NOT MATCHED THEN 
+                    INSERT (ProviderToMapCustomerProductId,
+                            ProviderID, 
+                            OfficeID, 
+                            ClientToProductID, 
+                            PhoneXML, 
+                            DisplayPhoneNumber)
+                    VALUES (UUID_STRING(),
+                            source.ProviderID, 
+                            source.OfficeID, 
+                            source.ClientToProductID, 
+                            source.PhoneXML, 
+                            source.DisplayPhoneNumber)';
+
+                    
+insert_statement_2 := ' MERGE INTO Base.ProviderToMapCustomerProduct as target USING 
+                   ('||select_statement || ' SELECT * FROM CTE_insert_2) as source 
+                   ON target.ProviderId = source.ProviderId AND target.OfficeId = source.OfficeId
+                   WHEN NOT MATCHED THEN 
+                    INSERT (ProviderToMapCustomerProductId,
+                            ProviderID, 
+                            OfficeID, 
+                            ClientToProductID, 
+                            PhoneXML, 
+                            DisplayPartnerCode)
+                    VALUES (UUID_STRING(),
+                            source.ProviderID, 
+                            source.OfficeID, 
+                            source.ClientToProductID, 
+                            source.PhoneXML, 
+                            source.DisplayPartnerCode)';
+                    
+ 
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE insert_statement_1 ;
+EXECUTE IMMEDIATE insert_statement_2 ;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+        
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '.f SQL State: ' || SQLSTATE;
+          RETURN status;
+
+
+    
+END;


### PR DESCRIPTION
--- The customerproductcode in the new json is taken from the key customerproduct not office
--- OFFICE_PHONENUMBER is displayphonenumber in the old json
--- there are a few values from the new json that are not there like trackingnumber, ringtonumber...
--- cte_providerofficecustomerproduct has joins that can not be possible because the codes are not in the json anymore
--- there is an update to cte_providerofficecustomerproduct to trackingnumber which can not be done because this item does not exist in the json
--- there is a delete to the table that does no longer make sense as it is taking data from a dedup table that does not exist anymore
--- the phonexml is constructed in a different format due to the new value of the phone in the new json. before we have this kinds of xml: <phone><ph>(888) 402-6916</ph><phTyp>PTODS</phTyp></phone> and now we have this: <phone><ph>3864288326</ph><phTyp>PTODS</phTyp></phone> where the phone has no other characters
--- there is a delte to the table when the length of the phonexml is lower than this len('<phone><phTyp>PTODS</phTyp></phone>'), i will add this to the where clause of my insert statements instead of writing a delete
--- providertomapcustomerproductid is not created anywhere, i addedd here as a uuid_String() in the merge
--- i am using p_json_to_xml and i changed it to utils schema instead of show