### PR TITLE
Base.ClientProductEntityRelationship

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityRelationship/spu_original_ClientProductEntityRelationship.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityRelationship/spu_original_ClientProductEntityRelationship.sql
@@ -1,0 +1,57 @@
+	if object_id('tempdb..#swimlane') is not null drop table #swimlane
+    select distinct x.ReltioEntityID,
+        x.OfficeID,
+        convert(uniqueidentifier, convert(varbinary(20), y.PracticeCode)) as PracticeID,
+        convert(uniqueidentifier, convert(varbinary(20), y.SourceCode)) as SourceID, 
+        y.LastUpdateDate, y.SourceCode, x.OfficeCode, y.PracticeCode, y.CustomerProductCode as ClientToProductCode,
+		cp.ClientToProductID,
+		convert(uniqueidentifier, HASHBYTES('SHA1', Concat(y.CustomerProductCode,rt.RelationshipTypeCode,y.PracticeCode,x.OfficeCode) )) as ClientProductEntityRelationshipID,
+		rt.RelationshipTypeID,
+        ROW_NUMBER() over(partition by x.OfficeID order by x.CREATE_DATE desc) as RowRank
+    into #swimlane
+    from
+    (
+        select w.* 
+        from
+        (
+            select p.CREATE_DATE, p.RELTIO_ID as ReltioEntityID, p.OFFICE_CODE as OfficeCode, p.OfficeID, 
+                json_query(p.PAYLOAD, '$.EntityJSONString.Practice') as OfficeJSON
+            from raw.OfficeProfileProcessingDeDup as d with (nolock)
+            inner join raw.OfficeProfileProcessing as p with (nolock) on p.rawOfficeProfileID = d.rawOfficeProfileID
+            where p.PAYLOAD is not null
+        ) as w
+        where w.OfficeJSON is not null
+    ) as x
+	join ODS1Stage.Base.RelationshipType rt on rt.RelationshipTypeCode = 'PRACTOOFF'
+    cross apply 
+    (
+        select *
+        from openjson(x.OfficeJSON) with (
+            CustomerProductCode varchar(50) '$.CustomerProductCode', 
+            LastUpdateDate datetime '$.LastUpdateDate', 
+            PracticeCode varchar(50) '$.PracticeCode', 
+            SourceCode varchar(25) '$.SourceCode')
+    ) as y
+    join ODS1Stage.Base.ClientToProduct as cp on cp.ClientToProductCode = y.CustomerProductCode
+	where y.CustomerProductCode is not null and y.PracticeCode is not null
+
+
+	if @OutputDestination = 'ODS1Stage' begin
+	    --Insert all ClientProductEntityRelationship records for PRACTOOFF
+		insert into ODS1Stage.Base.ClientProductEntityRelationship (ClientProductEntityRelationshipID, RelationshipTypeID, ParentID, ChildID, SourceCode, LastUpdateDate)
+		select s.ClientProductEntityRelationshipID, s.RelationshipTypeID, convert(uniqueidentifier, hashbytes('SHA1', concat(ClientToProductCode,pe.EntityTypeCode, s.PracticeCode) )) as ParentID,
+			convert(uniqueidentifier, hashbytes('SHA1', concat(ClientToProductCode,ce.EntityTypeCode,ReltioEntityID) )) as ChildID, isnull(s.SourceCode, 'Reltio') as SourceCode, 
+			isnull(s.LastUpdateDate, getutcdate()) as LastUpdateDate
+		from #swimlane s
+			join ODS1Stage.Base.EntityType pe on pe.EntityTypeCode='PRAC'
+			join ODS1Stage.Base.EntityType ce on ce.EntityTypeCode='OFFICE'
+			join ODS1Stage.Base.ClientProductToEntity cpep 
+				on convert(uniqueidentifier, HASHBYTES('SHA1', Concat(ClientToProductCode,pe.EntityTypeCode,PracticeCode) ))=cpep.ClientProductToEntityID
+			join ODS1Stage.Base.ClientProductToEntity cpeo 
+			on convert(uniqueidentifier, HASHBYTES('SHA1', Concat(ClientToProductCode,ce.EntityTypeCode,OfficeCode) ))=cpeo.ClientProductToEntityID
+		left join	ODS1Stage.Base.ClientProductEntityRelationship t
+					on t.ClientProductEntityRelationshipID = s.ClientProductEntityRelationshipID
+		where s.RowRank = 1
+			and cpep.ClientToProductID=cpeo.ClientToProductID
+			and t.ClientProductEntityRelationshipID is null
+	end

--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityRelationship/spu_translated_ClientProductEntityRelationship.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityRelationship/spu_translated_ClientProductEntityRelationship.sql
@@ -7,7 +7,7 @@ DECLARE
 ---------------------------------------------------------
 --------------- 0. Table dependencies -------------------
 ---------------------------------------------------------
---- Base,ClientProductEntityRelationship depends on:
+--- Base.ClientProductEntityRelationship depends on:
 -- RAW.VW_PROVIDER_PROFILE
 -- RAW.VW_OFFICE_PROFILE
 -- Base.Provider

--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityRelationship/spu_translated_ClientProductEntityRelationship.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityRelationship/spu_translated_ClientProductEntityRelationship.sql
@@ -1,0 +1,240 @@
+CREATE OR REPLACE PROCEDURE ODS1_STAGE.BASE.SP_LOAD_CLIENTPRODUCENTITYRELATIONSHIP()
+RETURNS STRING
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS  
+DECLARE 
+---------------------------------------------------------
+--------------- 0. Table dependencies -------------------
+---------------------------------------------------------
+--- Base,ClientProductEntityRelationship depends on:
+-- RAW.VW_PROVIDER_PROFILE
+-- RAW.VW_OFFICE_PROFILE
+-- Base.Provider
+-- Base.Facility
+-- Base.Office
+-- Base.RelationshipType
+-- Base.ClientToProduct
+-- Base.EntityType
+-- Base.ClientProductToEntity
+
+---------------------------------------------------------
+--------------- 1. Declaring variables ------------------
+---------------------------------------------------------
+
+select_statement_facility STRING;
+select_statement_office STRING;
+select_statement_practice STRING;
+insert_statement STRING; 
+merge_statement_facility STRING;
+merge_statement_office STRING;
+merge_statement_practice STRING;
+status STRING; -- Status monitoring
+
+---------------------------------------------------------
+--------------- 2.Conditionals if any -------------------
+---------------------------------------------------------   
+
+BEGIN
+-- no conditionals
+---------------------------------------------------------
+----------------- 3. SQL Statements ---------------------
+---------------------------------------------------------  
+
+------------ spuMergeProviderFacilityCustomerProduct ------------
+select_statement_facility := $$
+                            WITH CTE_swimlane AS (
+                                    SELECT DISTINCT
+                                    -- ReltioEntityId (deprecated)
+                                    p.ProviderID,
+                                    f.FacilityID,
+                                    -- SourceID (unused)
+                                    IFNULL(CUSTOMERPRODUCT_LASTUPDATEDATE, SYSDATE()) AS LastUpdateDate,
+                                    IFNULL(CUSTOMERPRODUCT_SOURCECODE, 'Profisee') AS SourceCode,
+                                    JSON.PROVIDERCODE, 
+                                    JSON.FACILITY_FACILITYCODE AS FacilityCode,
+                                    JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE AS ClientToProductCode,
+                                    cp.ClientToProductID,
+                                    rt.RelationshipTypeID,
+                                    rt.RelationshipTypeCode,
+                                    ROW_NUMBER() OVER(PARTITION BY p.ProviderID, f.FacilityID ORDER BY CREATE_DATE DESC) AS RowRank
+                                FROM RAW.VW_PROVIDER_PROFILE AS JSON
+                                LEFT JOIN Base.Provider p ON p.ProviderCode = JSON.ProviderCode
+                                INNER JOIN Base.Facility f ON f.FacilityCode = JSON.Facility_FacilityCode
+                                LEFT JOIN Base.RelationshipType rt ON rt.RelationshipTypeCode='PROVTOFAC'
+                                INNER JOIN Base.ClientToProduct cp ON cp.ClientToProductCode = JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE
+                                WHERE JSON.PROVIDER_PROFILE IS NOT NULL
+                            )
+                            
+                            SELECT 
+                                s.RelationshipTypeID,
+                                cptep.ClientProductToEntityID AS ParentID,
+                                cptef.ClientProductToEntityID AS ChildID,
+                                s.SourceCode,
+                                s.LastUpdateDate
+                            FROM CTE_Swimlane s
+                            INNER JOIN Base.EntityType prov ON prov.EntityTypeCode='PROV'
+                            INNER JOIN Base.EntityType fac ON fac.EntityTypeCode='FAC'
+                            INNER JOIN Base.ClientProductToEntity cptep ON s.ProviderID = cptep.EntityID
+                                AND prov.EntityTypeID = cptep.EntityTypeID 
+                            INNER JOIN Base.ClientProductToEntity cptef ON s.FacilityID = cptef.EntityID
+                                AND fac.EntityTypeID = cptef.EntityTypeID
+                            WHERE s.RowRank = 1 AND cptep.ClientToProductID = cptef.ClientToProductID
+                            $$;
+
+
+------------ spuMergeProviderOfficeCustomerProduct ------------
+select_statement_office := $$
+                            WITH CTE_swimlane AS (
+                                    SELECT DISTINCT
+                                    -- ReltioEntityId (deprecated)
+                                    p.ProviderID,
+                                    o.OfficeID,
+                                    -- SourceID (unused)
+                                    IFNULL(CUSTOMERPRODUCT_LASTUPDATEDATE, SYSDATE()) AS LastUpdateDate,
+                                    IFNULL(CUSTOMERPRODUCT_SOURCECODE, 'Profisee') AS SourceCode,
+                                    JSON.PROVIDERCODE, 
+                                    JSON.OFFICE_OFFICECODE AS OfficeCode,
+                                    JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE AS ClientToProductCode,
+                                    cp.ClientToProductID,
+                                    rt.RelationshipTypeID,
+                                    rt.RelationshipTypeCode,
+                                    ROW_NUMBER() OVER(PARTITION BY p.ProviderID, o.OfficeID ORDER BY CREATE_DATE DESC) AS RowRank
+                                FROM RAW.VW_PROVIDER_PROFILE AS JSON
+                                LEFT JOIN Base.Provider p ON p.ProviderCode = JSON.ProviderCode
+                                INNER JOIN Base.Office o ON o.OfficeCode = JSON.Office_OfficeCode
+                                LEFT JOIN Base.RelationshipType rt ON rt.RelationshipTypeCode='PROVTOOFF'
+                                INNER JOIN Base.ClientToProduct cp ON cp.ClientToProductCode = JSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE
+                                WHERE JSON.PROVIDER_PROFILE IS NOT NULL
+                            )
+                            
+                            SELECT 
+                                s.RelationshipTypeID,
+                                cptep.ClientProductToEntityID AS ParentID,
+                                cpteo.ClientProductToEntityID AS ChildID,
+                                s.SourceCode,
+                                s.LastUpdateDate
+                            FROM CTE_Swimlane s
+                            INNER JOIN Base.EntityType prov ON prov.EntityTypeCode='PROV'
+                            INNER JOIN Base.EntityType off ON off.EntityTypeCode='OFFICE'
+                            INNER JOIN Base.ClientProductToEntity cptep ON s.ProviderID = cptep.EntityID
+                                AND prov.EntityTypeID = cptep.EntityTypeID 
+                            INNER JOIN Base.ClientProductToEntity cpteo ON s.OfficeID = cpteo.EntityID
+                                AND off.EntityTypeID = cpteo.EntityTypeID
+                            WHERE s.RowRank = 1 AND cptep.ClientToProductID = cpteo.ClientToProductID
+                            $$;
+
+------------ spuMergePracticeOfficeCustomerProduct ------------
+select_statement_practice := $$
+                            WITH CTE_swimlane AS (
+                                SELECT DISTINCT
+                                -- ReltioEntityId (deprecated)
+                                o.OfficeID,
+                                p.PracticeID,
+                                -- SourceID (unused)
+                                SYSDATE() AS LastUpdateDate,
+                                'Profisee' AS SourceCode,
+                                JSON.PRACTICE_PRACTICECODE AS PracticeCode, 
+                                JSON.OFFICECODE AS OfficeCode,
+                                ProviderJSON.CUSTOMERPRODUCT_CUSTOMERPRODUCTCODE AS ClientToProductCode,
+                                cp.ClientToProductID,
+                                rt.RelationshipTypeID,
+                                rt.RelationshipTypeCode,
+                                ROW_NUMBER() OVER(PARTITION BY o.OfficeID ORDER BY JSON.CREATE_DATE DESC) AS RowRank
+                            FROM RAW.VW_OFFICE_PROFILE AS JSON
+                            LEFT JOIN Base.Practice p ON p.PracticeCode = JSON.PRACTICE_PRACTICECODE
+                            INNER JOIN Base.Office o ON o.OfficeCode = JSON.OFFICECODE
+                            LEFT JOIN Base.RelationshipType rt ON rt.RelationshipTypeCode='PRACTOOFF'
+                            LEFT JOIN RAW.VW_PROVIDER_PROFILE ProviderJSON ON JSON.OFFICECODE = ProviderJSON.OFFICE_OFFICECODE
+                            INNER JOIN Base.ClientToProduct cp ON cp.ClientToProductCode = ClientToProductCode
+                            WHERE JSON.OFFICE_PROFILE IS NOT NULL
+                        )
+                        
+                        SELECT 
+                            s.RelationshipTypeID,
+                            cptep.ClientProductToEntityID AS ParentID,
+                            cpteo.ClientProductToEntityID AS ChildID,
+                            s.SourceCode,
+                            s.LastUpdateDate
+                        FROM CTE_Swimlane s
+                        INNER JOIN Base.EntityType prac ON prac.EntityTypeCode='PRAC'
+                        INNER JOIN Base.EntityType off ON off.EntityTypeCode='OFFICE'
+                        INNER JOIN Base.ClientProductToEntity cptep ON s.PracticeID = cptep.EntityID
+                            AND prac.EntityTypeID = cptep.EntityTypeID 
+                        INNER JOIN Base.ClientProductToEntity cpteo ON s.OfficeID = cpteo.EntityID
+                            AND off.EntityTypeID = cpteo.EntityTypeID
+                        WHERE s.RowRank = 1 AND cptep.ClientToProductID = cpteo.ClientToProductID
+                        $$;
+
+                
+insert_statement := $$ 
+                    INSERT  
+                        (
+                         ClientProductEntityRelationshipID, 
+                         RelationshipTypeID, 
+                         ParentID, 
+                         ChildID, 
+                         SourceCode,
+                         LastUpdateDate
+                         )
+                    VALUES 
+                        (
+                        UUID_STRING(),
+                        source.RelationshipTypeID,
+                        source.ParentID,
+                        source.ChildID,
+                        source.SourceCode,
+                        source.LastUpdateDate
+                        )
+                    $$;
+
+
+---------------------------------------------------------
+--------- 4. Actions (Inserts and Updates) --------------
+---------------------------------------------------------  
+
+merge_statement_facility := $$ MERGE INTO Base.ClientProductEntityRelationship as target USING 
+                           ($$||select_statement_facility||$$) as source 
+                           ON source.RelationshipTypeID = target.RelationshipTypeID
+                            AND source.ParentID = target.ParentID AND source.ChildID = target.ChildID
+                           WHEN NOT MATCHED THEN $$||insert_statement;
+                           
+
+merge_statement_office := $$ MERGE INTO Base.ClientProductEntityRelationship as target USING 
+                           ($$||select_statement_office||$$) as source 
+                           ON source.RelationshipTypeID = target.RelationshipTypeID
+                            AND source.ParentID = target.ParentID AND source.ChildID = target.ChildID
+                           WHEN NOT MATCHED THEN $$||insert_statement;
+
+
+merge_statement_practice := $$ MERGE INTO Base.ClientProductEntityRelationship as target USING 
+                           ($$||select_statement_practice||$$) as source 
+                           ON source.RelationshipTypeID = target.RelationshipTypeID
+                            AND source.ParentID = target.ParentID AND source.ChildID = target.ChildID
+                           WHEN NOT MATCHED THEN $$||insert_statement;
+
+    
+---------------------------------------------------------
+------------------- 5. Execution ------------------------
+--------------------------------------------------------- 
+
+EXECUTE IMMEDIATE merge_statement_facility;
+EXECUTE IMMEDIATE merge_statement_office;
+EXECUTE IMMEDIATE merge_statement_practice;
+
+---------------------------------------------------------
+--------------- 6. Status monitoring --------------------
+--------------------------------------------------------- 
+
+status := 'Completed successfully';
+    RETURN status;
+
+
+
+EXCEPTION
+    WHEN OTHER THEN
+          status := 'Failed during execution. ' || 'SQL Error: ' || SQLERRM || ' Error code: ' || SQLCODE || '. SQL State: ' || SQLSTATE;
+          RETURN status;
+
+
+END;


### PR DESCRIPTION
This table depended on 6 stored procedures. Rawfile is a dead schema and the other 2 only use it for joins or perform meaningless deletes that can be safely ignored with MERGE statements since they are done to prevent duplicate insertion. Something to note is that CUSTOMERPRODUCT is no longer in the new Office JSON - I obtained these in a hacky way with a JOIN with the Provider JSON on OFFICECODE column (thanks for the tip Clau). 

Something to note in the future is that merge_statement_office takes ~1 minute to run, which seems excessive considering the sample size. The bottleneck here is the absurd window function - commenting that line makes the code run in 1 second.
