### PR TITLE
report + code

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/FacilityImage/BASE.FACILITYIMAGE-report.md
+++ b/migration_original/ODS1Stage/tables/Base/FacilityImage/BASE.FACILITYIMAGE-report.md
@@ -1,0 +1,50 @@
+# BASE.FACILITYIMAGE Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/10).
+Percentage of Different Columns: 0.00% (0/10).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 10
+- Snowflake: 10
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 488
+- Snowflake: 356
+- Rows Margin (%): 27.049180327868854
+
+### 2.3 Nulls per Column
+|    | Column_Name        |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:-------------------|------------------------:|------------------------:|-------------:|
+|  0 | FacilityImageID    |                       0 |                       0 |            0 |
+|  1 | FacilityID         |                       0 |                       0 |            0 |
+|  2 | FileName           |                       0 |                       0 |            0 |
+|  3 | MediaImageTypeID   |                       0 |                       0 |            0 |
+|  4 | MediaSizeID        |                       0 |                       0 |            0 |
+|  5 | MediaReviewLevelID |                       0 |                       0 |            0 |
+|  6 | FacilityImage      |                     488 |                     356 |           27 |
+|  7 | SourceCode         |                       0 |                       0 |            0 |
+|  8 | LastUpdateDate     |                       0 |                       0 |            0 |
+|  9 | ImagePath          |                       2 |                       2 |            0 |
+
+### 2.4 Distincts per Column
+|    | Column_Name        |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:-------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | FacilityImageID    |                         488 |                         356 |         27   |
+|  1 | FacilityID         |                         488 |                         355 |         27.3 |
+|  2 | FileName           |                         479 |                         349 |         27.1 |
+|  3 | MediaImageTypeID   |                           2 |                           1 |         50   |
+|  4 | MediaSizeID        |                           1 |                           1 |          0   |
+|  5 | MediaReviewLevelID |                           1 |                           1 |          0   |
+|  6 | SourceCode         |                           4 |                          38 |        850   |
+|  7 | LastUpdateDate     |                           5 |                          59 |       1080   |
+|  8 | ImagePath          |                           2 |                           1 |         50   |


### PR DESCRIPTION
The reason why there is a facility that has 2 differnt images is because there is a typo in the json from the mdm side. The table is okey for the rest.

for reference this query to see how for this facility the same image is duplicated with a typo in the filename:
SELECT
    p.ref_facility_code as facilitycode,
    to_varchar(json.value:S3_PREFIX) as Image_Path, 
    to_varchar(json.value:FACILITY_IMAGE_FILE_NAME) as Image_FileName,
    to_varchar(json.value:MEDIA_IMAGE_TYPE_CODE) as Image_TypeCode,
    to_varchar(json.value:MEDIA_SIZE_CODE) as Image_SizeCode,
    to_varchar(json.value:MEDIA_REVIEW_LEVEL_CODE) as Image_ReviewLevel,
    to_varchar(json.value:DATA_SOURCE_CODE) as Image_SourceCode,
    to_timestamp_ntz(json.value:UPDATED_DATETIME) as Image_LastUpdateDate
FROM mdm_team.mst.facility_profile_processing as p
, lateral flatten(input => p.FACILITY_PROFILE:IMAGE) as json
where
    facilitycode = 'F57D0B';