### PR TITLE
Base.ProviderToClientProductToDisplayPartner Validation

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/BASE.PROVIDERTOCLIENTPRODUCTTODISPLAYPARTNER-report.md
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/BASE.PROVIDERTOCLIENTPRODUCTTODISPLAYPARTNER-report.md
@@ -1,0 +1,43 @@
+# Base.ProviderToClientProductToDisplayPartner Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/6).
+Percentage of Different Columns: 0.00% (0/6).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 6
+- Snowflake: 6
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 19192
+- Snowflake: 19128
+- Rows Margin (%): 0.3334722801167153
+
+### 2.3 Nulls per Column
+|    | Column_Name          |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:---------------------|------------------------:|------------------------:|-------------:|
+|  0 | ProviderCPDPID       |                       0 |                       0 |            0 |
+|  1 | ProviderID           |                       0 |                       0 |            0 |
+|  2 | ClientToProductID    |                       0 |                       0 |            0 |
+|  3 | SyndicationPartnerID |                       0 |                       0 |            0 |
+|  4 | SourceCode           |                       0 |                       0 |            0 |
+|  5 | LastUpdateDate       |                       0 |                       0 |            0 |
+
+### 2.4 Distincts per Column
+|    | Column_Name          |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:---------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ProviderCPDPID       |                       19192 |                       19128 |          0.3 |
+|  1 | ProviderID           |                       13574 |                       13510 |          0.5 |
+|  2 | ClientToProductID    |                           8 |                           8 |          0   |
+|  3 | SyndicationPartnerID |                           4 |                           4 |          0   |
+|  4 | SourceCode           |                           1 |                          10 |        900   |
+|  5 | LastUpdateDate       |                           1 |                          21 |       2000   |

--- a/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/spu_translated_ProviderToClientProductToDisplayPartner.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/spu_translated_ProviderToClientProductToDisplayPartner.sql
@@ -21,8 +21,9 @@ select_statement string;
 insert_statement string;
 merge_statement string;
 status string;
-    procedure_name varchar(50) default('sp_load_providertoclientproducttodisplaypartner');
-    execution_start datetime default getdate();
+procedure_name varchar(50) default('sp_load_providertoclientproducttodisplaypartner');
+execution_start datetime default getdate();
+mdm_db string default('mdm_team');
 
 begin
 
@@ -39,7 +40,7 @@ select_statement := $$
                             to_varchar(partner.value:DISPLAY_PARTNER_CODE) as customerproduct_DisplayPartner,
                             to_varchar(json.value:DATA_SOURCE_CODE) as customerproduct_SourceCode,
                             to_timestamp_ntz(json.value:UPDATED_DATETIME) as customerproduct_LastUpdateDate
-                        from mdm_team.mst.provider_profile_processing as p,
+                        from $$ || mdm_db || $$.mst.provider_profile_processing as p,
                         lateral flatten(input => p.PROVIDER_PROFILE:CUSTOMER_PRODUCT) as json,
                         lateral flatten(input => json.value:DISPLAY_PARTNER) as partner
                     )

--- a/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/spu_translated_ProviderToClientProductToDisplayPartner.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/spu_translated_ProviderToClientProductToDisplayPartner.sql
@@ -23,6 +23,7 @@ merge_statement string;
 status string;
     procedure_name varchar(50) default('sp_load_providertoclientproducttodisplaypartner');
     execution_start datetime default getdate();
+mdm_db string default('mdm_team');
 
 begin
 
@@ -39,13 +40,13 @@ select_statement := $$
                             to_varchar(partner.value:DISPLAY_PARTNER_CODE) as customerproduct_DisplayPartner,
                             to_varchar(json.value:DATA_SOURCE_CODE) as customerproduct_SourceCode,
                             to_timestamp_ntz(json.value:UPDATED_DATETIME) as customerproduct_LastUpdateDate
-                        from mdm_team.mst.provider_profile_processing as p,
+                        from $$||mdm_db||$$.mst.provider_profile_processing as p,
                         lateral flatten(input => p.PROVIDER_PROFILE:CUSTOMER_PRODUCT) as json,
                         lateral flatten(input => json.value:DISPLAY_PARTNER) as partner
                         
                     )
                     
-                    select distinct
+                    select
                         p.providerid,
                         cp.clienttoproductid,
                         sp.syndicationpartnerid,

--- a/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/spu_translated_ProviderToClientProductToDisplayPartner.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToClientProductToDisplayPartner/spu_translated_ProviderToClientProductToDisplayPartner.sql
@@ -23,6 +23,7 @@ merge_statement string;
 status string;
     procedure_name varchar(50) default('sp_load_providertoclientproducttodisplaypartner');
     execution_start datetime default getdate();
+    mdm_db string default('mdm_team');
 
 begin
 
@@ -39,7 +40,7 @@ select_statement := $$
                             to_varchar(partner.value:DISPLAY_PARTNER_CODE) as customerproduct_DisplayPartner,
                             to_varchar(json.value:DATA_SOURCE_CODE) as customerproduct_SourceCode,
                             to_timestamp_ntz(json.value:UPDATED_DATETIME) as customerproduct_LastUpdateDate
-                        from mdm_team.mst.provider_profile_processing as p,
+                        from $$|| mdm_db ||$$.mst.provider_profile_processing as p,
                         lateral flatten(input => p.PROVIDER_PROFILE:CUSTOMER_PRODUCT) as json,
                         lateral flatten(input => json.value:DISPLAY_PARTNER) as partner
                     )


### PR DESCRIPTION
Fixed 0 rows issue mentioned here: https://github.com/carresemata/xtillion_healthgrades_migration/pull/99/files. It was due to the select statement - I added lateral flatten to DISPLAY_PARTNER which was also a list of dictionaries. The inner join was the cause of the 0 rows. 

Cannot perform sample validation since we only have IDs, but aggregate statistics match. Almost exactly the same amount of rows, and only difference is more distinct values in SourceCode and LastUpdateDate. 