### PR TITLE
Base.ClientProductToCallCenter Validation

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/BASE.CLIENTPRODUCTTOCALLCENTER-report.md
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/BASE.CLIENTPRODUCTTOCALLCENTER-report.md
@@ -1,0 +1,43 @@
+# Base.ClientProductToCallCenter Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/6).
+Percentage of Different Columns: 0.00% (0/6).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 6
+- Snowflake: 6
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 174
+- Snowflake: 157
+- Rows Margin (%): 9.770114942528735
+
+### 2.3 Nulls per Column
+|    | Column_Name                 |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:----------------------------|------------------------:|------------------------:|-------------:|
+|  0 | ClientProductToCallCenterID |                       0 |                       0 |            0 |
+|  1 | ClientToProductID           |                       0 |                       0 |            0 |
+|  2 | CallCenterID                |                       0 |                       0 |            0 |
+|  3 | ActiveFlag                  |                       0 |                       0 |            0 |
+|  4 | SourceCode                  |                       0 |                       0 |            0 |
+|  5 | LastUpdateDate              |                       0 |                       0 |            0 |
+
+### 2.4 Distincts per Column
+|    | Column_Name                 |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:----------------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ClientProductToCallCenterID |                         174 |                         157 |          9.8 |
+|  1 | ClientToProductID           |                         173 |                         157 |          9.2 |
+|  2 | CallCenterID                |                          34 |                          34 |          0   |
+|  3 | ActiveFlag                  |                           2 |                           1 |         50   |
+|  4 | SourceCode                  |                           3 |                         111 |       3600   |
+|  5 | LastUpdateDate              |                         123 |                          40 |         67.5 |

--- a/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/spu_translated_ClientProductToCallCenter.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/spu_translated_ClientProductToCallCenter.sql
@@ -10,7 +10,6 @@ declare
 
 --- base.clientproducttocallcenter depends on:
 --- base.clienttoproduct
---- base.callcenter
 --- base.product
 --- base.client
 

--- a/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/spu_translated_ClientProductToCallCenter.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/spu_translated_ClientProductToCallCenter.sql
@@ -35,37 +35,19 @@ begin
 
 --- select Statement
 -- if no conditionals:
-select_statement := $$with cte_product_id_pdchsp as (
-        select
-            cpcc.clienttoproductid
-        from
-            base.clientproducttocallcenter as CPCC
-            join base.clienttoproduct as CTP on cpcc.clienttoproductid = ctp.clienttoproductid
-            join base.callcenter as CC on cpcc.callcenterid = cc.callcenterid
-            join base.product as P on ctp.productid = p.productid
-        where
-            p.productcode IN ('MAP', 'PDCHSP')
-    )
-    select
-        cp.clienttoproductid,
-        '36334343-0000-0000-0000-000000000000' as CallCenterID,
-        1 as ActiveFlag,
-        cp.sourcecode,
-        getdate() as LastUpdateDate
-    from
-        base.clienttoproduct as CP
-        join base.product as P on cp.productid = p.productid
-        join base.client as c on c.clientid = cp.clientid
-        left join cte_product_id_pdchsp as CTE on cp.clienttoproductid = cte.clienttoproductid
-    where
-    (
-        p.productcode IN ('PDCHSP')
-        or (
-            p.productcode IN ('MAP')
-            and ClientCode IN ('COMO', 'PAGE1SLN')
-        )
-    )
-$$;
+select_statement := $$
+                    select
+                        cp.clienttoproductid,
+                        '36334343-0000-0000-0000-000000000000' as CallCenterID,
+                        1 as ActiveFlag,
+                        cp.sourcecode,
+                        getdate() as LastUpdateDate
+                    from
+                        base.clienttoproduct as CP
+                        join base.product as P on cp.productid = p.productid
+                        join base.client as c on c.clientid = cp.clientid
+                    where (p.productcode IN ('PDCHSP') or (p.productcode IN ('MAP') and ClientCode IN ('COMO', 'PAGE1SLN')))
+                    $$;
 
 --- insert Statement
 insert_statement := ' insert (ClientProductToCallCenterID,ClientToProductID, CallCenterID, ActiveFlag, SourceCode, LastUpdateDate)
@@ -87,7 +69,8 @@ merge_statement := ' merge into base.clientproducttocallcenter as target using
 ---------------------------------------------------------
 
 if (is_full) then
-    truncate table Base.ClientProductToCallCenter;
+    delete from base.clientproducttocallcenter
+    where callcenterid = '36334343-0000-0000-0000-000000000000';
 end if; 
 execute immediate merge_statement;
 

--- a/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/spu_translated_ClientProductToCallCenter.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductToCallCenter/spu_translated_ClientProductToCallCenter.sql
@@ -33,7 +33,6 @@ begin
 ---------------------------------------------------------     
 
 --- select Statement
--- if no conditionals:
 select_statement := $$
                     select
                         cp.clienttoproductid,


### PR DESCRIPTION
This one was tricky. Here is the thing: the way the current stored procedure is written it only adds new call center records. However, the actual table in SQL Server still has a few legacy records that have not been updated for a long time which are not part of the insert statement. I also had to delete code since it was joining with the table itself (which does not make sense for full refresh). 

I talked to Matt and we may want to preserve those legacy records just in case. For this reason, we cannot truncate this table in the full refresh since it is now holding legacy data. What I did instead was delete the records that are being updated by the procedure (which always correspond to the ID '36334343-0000-0000-0000-000000000000'). 

Cannot perform sample validation since there are no matching PKs. The aggregate statistics look good: large margin for SourceCode is unrelated to this stored procedure since that comes straight from base.clienttoproduct which has already been validated, and the LastUpdateDate does not come from the json (inserted in runtime). 

**Final Note: This is a relationship table. Which means that for these legacy records to be actually used in the pipeline their respective foreign keys may need to be retrieved as well.**