### PR TITLE
Mid.ProviderHealthInsurance Validation

### DIFF
--- a/migration_original/ODS1Stage/tables/Mid/ProviderHealthInsurance/MID.PROVIDERHEALTHINSURANCE-report.md
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderHealthInsurance/MID.PROVIDERHEALTHINSURANCE-report.md
@@ -1,0 +1,57 @@
+# Mid.ProviderHealthInsurance Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/13).
+Percentage of Different Columns: 0.00% (0/13).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 13
+- Snowflake: 13
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 38592898
+- Snowflake: 35156511
+- Rows Margin (%): 8.904195274477702
+
+### 2.3 Nulls per Column
+|    | Column_Name                     |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:--------------------------------|------------------------:|------------------------:|-------------:|
+|  0 | ProviderToHealthInsuranceID     |                       0 |                       0 |          0   |
+|  1 | ProviderID                      |                       0 |                       0 |          0   |
+|  2 | HealthInsurancePlanToPlanTypeID |                       0 |                       0 |          0   |
+|  3 | ProductName                     |                       0 |                       0 |          0   |
+|  4 | PlanName                        |                       0 |                       0 |          0   |
+|  5 | PlanDisplayName                 |                       0 |                       0 |          0   |
+|  6 | PayorName                       |                       0 |                       0 |          0   |
+|  7 | PlanTypeDescription             |                10181461 |                 9896137 |          2.8 |
+|  8 | PlanTypeDisplayDescription      |                10181461 |                 9896137 |          2.8 |
+|  9 | Searchable                      |                       0 |                       0 |          0   |
+| 10 | PayorCode                       |                 3189788 |                       0 |        100   |
+| 11 | HealthInsurancePayorID          |                       0 |                       0 |          0   |
+| 12 | PayorProductCount               |                       0 |                       0 |          0   |
+
+### 2.4 Distincts per Column
+|    | Column_Name                     |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:--------------------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ProviderToHealthInsuranceID     |                    38592898 |                    35156511 |          8.9 |
+|  1 | ProviderID                      |                     2849266 |                     2832636 |          0.6 |
+|  2 | HealthInsurancePlanToPlanTypeID |                        6904 |                        6227 |          9.8 |
+|  3 | ProductName                     |                        6276 |                        5624 |         10.4 |
+|  4 | PlanName                        |                        5223 |                        4585 |         12.2 |
+|  5 | PlanDisplayName                 |                        5223 |                        4585 |         12.2 |
+|  6 | PayorName                       |                        1383 |                         781 |         43.5 |
+|  7 | PlanTypeDescription             |                          58 |                          58 |          0   |
+|  8 | PlanTypeDisplayDescription      |                          58 |                          58 |          0   |
+|  9 | Searchable                      |                           2 |                           1 |         50   |
+| 10 | PayorCode                       |                        1361 |                         781 |         42.6 |
+| 11 | HealthInsurancePayorID          |                        1383 |                         781 |         43.5 |
+| 12 | PayorProductCount               |                          86 |                          85 |          1.2 |

--- a/migration_original/ODS1Stage/tables/Mid/ProviderHealthInsurance/spu_translated_ProviderHealthInsurance.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderHealthInsurance/spu_translated_ProviderHealthInsurance.sql
@@ -43,7 +43,7 @@ select_statement := $$
                         select
                             p.providerid
                         from
-                            mdm_team.mst.Provider_Profile_Processing as ppp
+                            $$||mdm_db||$$.mst.Provider_Profile_Processing as ppp
                         join base.provider as P on p.providercode = ppp.ref_provider_code
                     ),
                     CTE_PayorProductCount as (

--- a/migration_original/ODS1Stage/tables/Mid/ProviderHealthInsurance/spu_translated_ProviderHealthInsurance.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderHealthInsurance/spu_translated_ProviderHealthInsurance.sql
@@ -38,55 +38,56 @@ declare
 begin
 --- select Statement
 
-select_statement := $$  with CTE_ProviderBatch as (
-            select
-                    p.providerid
-                from
-                    $$ || mdm_db || $$.mst.Provider_Profile_Processing as ppp
-                    join base.provider as P on p.providercode = ppp.ref_provider_code
-        ),
-        CTE_PayorProductCount as (
-                            select
+select_statement := $$  
+                    with CTE_ProviderBatch as (
+                        select
+                            p.providerid
+                        from
+                            mdm_team.mst.Provider_Profile_Processing as ppp
+                        join base.provider as P on p.providercode = ppp.ref_provider_code
+                    ),
+                    CTE_PayorProductCount as (
+                        select
                             hipay.payorcode,
                             COUNT(*) as PayorProductCount
-                            from
-                                base.healthinsuranceplantoplantype as hipt
-                                join base.healthinsuranceplan as hip on hipt.healthinsuranceplanid = hip.healthinsuranceplanid
-                                join base.healthinsurancepayor as hipay on hip.healthinsurancepayorid = hipay.healthinsurancepayorid
-                            where
-                                hipay.payorname != hipt.productname
-                            group by
-                                hipay.payorcode
-                        )
-                        select
-                            distinct pthi.providertohealthinsuranceid,
-                            pthi.providerid,
-                            hipt.healthinsuranceplantoplantypeid,
-                            hipt.productname,
-                            hip.planname,
-                            hip.plandisplayname,
-                            hipay.payorname,
-                            hiptd.plantypedescription,
-                            hiptd.plantypedisplaydescription,
-                            CASE
-                                WHEN hipay.payorname IN (
-                                    'Name of Insurance Unknown',
-                                    'Accepts most insurance',
-                                    'Accepts most major Health Plans. Please contact our office for details.'
-                                ) then 0
-                                else 1
-                            END as Searchable,
-                            hipay.payorcode,
-                            hipay.healthinsurancepayorid,
-                            pc.payorproductcount
                         from
-                            CTE_ProviderBatch as pb
-                            join base.providertohealthinsurance as pthi on pthi.providerid = pb.providerid
-                            join base.healthinsuranceplantoplantype as hipt on pthi.healthinsuranceplantoplantypeid = hipt.healthinsuranceplantoplantypeid
+                            base.healthinsuranceplantoplantype as hipt
                             join base.healthinsuranceplan as hip on hipt.healthinsuranceplanid = hip.healthinsuranceplanid
-                            join base.healthinsurancepayor as hipay on hip.healthinsurancepayorid = hipay.healthinsurancepayorid
-                            join base.healthinsuranceplantype as hiptd on hipt.healthinsuranceplantypeid = hiptd.healthinsuranceplantypeid
-                            join CTE_PayorProductCount as pc on pc.payorcode = hipay.payorcode
+                            right join base.healthinsurancepayor as hipay on hip.healthinsurancepayorid = hipay.healthinsurancepayorid
+                        where
+                            hipay.payorname != hipt.productname
+                        group by
+                            hipay.payorcode
+                    )
+                    select distinct
+                        pthi.providertohealthinsuranceid,
+                        pthi.providerid,
+                        hipt.healthinsuranceplantoplantypeid,
+                        hipt.productname,
+                        hip.planname,
+                        hip.plandisplayname,
+                        hipay.payorname,
+                        hiptd.plantypedescription,
+                        hiptd.plantypedisplaydescription,
+                        CASE
+                            WHEN hipay.payorname IN (
+                                'Name of Insurance Unknown',
+                                'Accepts most insurance',
+                                'Accepts most major Health Plans. Please contact our office for details.'
+                            ) then 0
+                            else 1
+                        END as Searchable,
+                        hipay.payorcode,
+                        hipay.healthinsurancepayorid,
+                        pc.payorproductcount,
+                    from
+                        CTE_ProviderBatch as pb
+                        join base.providertohealthinsurance as pthi on pthi.providerid = pb.providerid
+                        join base.healthinsuranceplantoplantype as hipt on pthi.healthinsuranceplantoplantypeid = hipt.healthinsuranceplantoplantypeid
+                        join base.healthinsuranceplan as hip on hipt.healthinsuranceplanid = hip.healthinsuranceplanid
+                        join base.healthinsurancepayor as hipay on hip.healthinsurancepayorid = hipay.healthinsurancepayorid
+                        join base.healthinsuranceplantype as hiptd on hipt.healthinsuranceplantypeid = hiptd.healthinsuranceplantypeid
+                        join CTE_PayorProductCount as pc on pc.payorcode = hipay.payorcode
                     $$;
 
 --- update Statement
@@ -106,16 +107,16 @@ update_statement := ' update
 
 --- update Condition
 update_condition := 'target.healthinsurancepayorid != source.healthinsurancepayorid
-        or target.healthinsuranceplantoplantypeid != source.healthinsuranceplantoplantypeid
-        or target.payorcode != source.payorcode
-        or target.payorname != source.payorname
-        or target.plandisplayname != source.plandisplayname
-        or target.planname != source.planname
-        or target.plantypedescription != source.plantypedescription
-        or target.plantypedisplaydescription != source.plantypedisplaydescription
-        or target.productname != source.productname
-        or target.providerid != source.providerid
-        or target.searchable != source.searchable';
+                            or target.healthinsuranceplantoplantypeid != source.healthinsuranceplantoplantypeid
+                            or target.payorcode != source.payorcode
+                            or target.payorname != source.payorname
+                            or target.plandisplayname != source.plandisplayname
+                            or target.planname != source.planname
+                            or target.plantypedescription != source.plantypedescription
+                            or target.plantypedisplaydescription != source.plantypedisplaydescription
+                            or target.productname != source.productname
+                            or target.providerid != source.providerid
+                            or target.searchable != source.searchable';
 
 --- insert Statement
 insert_statement := ' insert
@@ -155,10 +156,10 @@ insert_statement := ' insert
 ---------------------------------------------------------  
 
 
-merge_statement := ' merge into show.providerhealthinsurance as target using 
+merge_statement := ' merge into mid.providerhealthinsurance as target using 
                    ('||select_statement||') as source 
                    on target.providertohealthinsuranceid = source.providertohealthinsuranceid
-                   WHEN MATCHED and (' || update_condition || ') then '||update_statement|| '
+                   WHEN MATCHED and ('||update_condition||') then '||update_statement|| '
                    when not matched then '||insert_statement;
                    
 ---------------------------------------------------------


### PR DESCRIPTION
Cannot do sample validation because of no matching PKs. Aggregate validation looks good overall: similar total rows and nulls within margin. There are 3 columns with a large margin of distincts but it's hard to trace why this is happening without a sample validation. I checked the stored procedure line by line and with the exception of changing a join to a right join like it was in SQL Server the rest of the code looks good to me.