### PR TITLE
Base.ProviderToSubStatus Validation

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProviderToSubStatus/Base.PROVIDERTOSUBSTATUS-report.md
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToSubStatus/Base.PROVIDERTOSUBSTATUS-report.md
@@ -1,0 +1,49 @@
+# Base.ProviderToSubStatus Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/9).
+Percentage of Different Columns: 0.00% (0/9).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 9
+- Snowflake: 9
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 8804876
+- Snowflake: 13266636
+- Rows Margin (%): 50.67374032297559
+
+### 2.3 Nulls per Column
+|    | Column_Name           |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:----------------------|------------------------:|------------------------:|-------------:|
+|  0 | ProviderToSubStatusID |                       0 |                       0 |          0   |
+|  1 | ProviderID            |                       0 |                       0 |          0   |
+|  2 | SubStatusID           |                       0 |                       0 |          0   |
+|  3 | HierarchyRank         |                       0 |                       0 |          0   |
+|  4 | SubStatusValueA       |                 8804876 |                13266636 |         50.7 |
+|  5 | LegacyKey             |                 8804876 |                13266636 |         50.7 |
+|  6 | LegacyKeyName         |                 8804876 |                13266636 |         50.7 |
+|  7 | SourceCode            |                       0 |                       0 |          0   |
+|  8 | LastUpdateDate        |                       1 |                       0 |        100   |
+
+### 2.4 Distincts per Column
+|    | Column_Name           |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:----------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ProviderToSubStatusID |                     8804876 |                    13266636 |         50.7 |
+|  1 | ProviderID            |                     6452848 |                     6522348 |          1.1 |
+|  2 | SubStatusID           |                          29 |                          29 |          0   |
+|  3 | HierarchyRank         |                           6 |                           6 |          0   |
+|  4 | SubStatusValueA       |                           0 |                           0 |          0   |
+|  5 | LegacyKey             |                           0 |                           0 |          0   |
+|  6 | LegacyKeyName         |                           0 |                           0 |          0   |
+|  7 | SourceCode            |                         185 |                         217 |         17.3 |
+|  8 | LastUpdateDate        |                         735 |                         676 |          8   |

--- a/migration_original/ODS1Stage/tables/Base/ProviderToSubStatus/spu_translated_ProviderToSubStatus.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToSubStatus/spu_translated_ProviderToSubStatus.sql
@@ -82,7 +82,7 @@ insert_statement := ' insert
 
 merge_statement := ' merge into base.providertosubstatus as target using 
                    ('||select_statement||') as source 
-                   on source.providerid = target.providerid
+                   on source.providerid = target.providerid and source.substatusid = target.substatusid
                    WHEN MATCHED then delete
                    when not matched then '||insert_statement;
                    

--- a/migration_original/ODS1Stage/tables/Base/ProviderToSubStatus/spu_translated_ProviderToSubStatus.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderToSubStatus/spu_translated_ProviderToSubStatus.sql
@@ -9,7 +9,7 @@ declare
 ---------------------------------------------------------
     
 -- base.providertosubstatus depends on: 
---- mdm_team.mst.provider_profile_processing (raw.vw_provider_profile)
+--- mdm_team.mst.provider_profile_processing 
 --- base.provider
 --- base.substatus
 
@@ -23,6 +23,7 @@ declare
     status string; -- status monitoring
     procedure_name varchar(50) default('sp_load_providertosubstatus');
     execution_start datetime default getdate();
+    mdm_db string default('mdm_team');
 
    
    
@@ -35,20 +36,28 @@ begin
 ---------------------------------------------------------     
 
 --- select Statement
-select_statement := 'select distinct
+select_statement := $$
+                    with cte_providerstatus as (
+                        select
+                            p.ref_provider_code as providercode,
+                            to_varchar(json.value:PROVIDER_STATUS_CODE) as providerstatus_ProviderStatusCode,
+                            to_varchar(json.value:PROVIDER_STATUS_RANK) as providerstatus_ProviderStatusRank,
+                            to_varchar(json.value:DATA_SOURCE_CODE) as providerstatus_SourceCode,
+                            to_timestamp_ntz(json.value:UPDATED_DATETIME) as providerstatus_LastUpdateDate
+                        from $$||mdm_db||$$.mst.provider_profile_processing as p,
+                        lateral flatten(input => p.PROVIDER_PROFILE:PROVIDER_STATUS) as json
+                    )
+                    
+                    select distinct
                         p.providerid,
                         s.substatusid,
                         ifnull(json.providerstatus_ProviderStatusRank, 2147483647) as HierarchyRank,
                         json.providerstatus_SourceCode as SourceCode,
                         json.providerstatus_LastUpdateDate as LastUpdateDate
-                    from raw.vw_PROVIDER_PROFILE as JSON
-                        left join base.provider as P on p.providercode = json.providercode
-                        left join base.substatus as S on s.substatuscode = json.providerstatus_ProviderStatusCode
-                    where 
-                        PROVIDER_PROFILE is not null and
-                        ProviderId is not null and
-                        ProviderStatus_ProviderStatusCode is not null
-                    qualify row_number() over( partition by ProviderID, ProviderStatus_ProviderStatusCode order by CREATE_DATE desc) = 1';
+                    from cte_providerstatus as json
+                    join base.provider as p on p.providercode = json.providercode
+                    join base.substatus as s on s.substatuscode = json.providerstatus_ProviderStatusCode
+                    where providerstatus_ProviderStatusCode is not null$$;
 
 
 --- insert Statement


### PR DESCRIPTION
Changed select statement to lateral flatten format, deleted window function.

Cannot perform sample validation because we don't have PKs. The large margins in the aggregate validation are all due to the fact that apparently we have a lot more rows in Snowflake - but this comes straight from the lateral flatten select statement so it's not a translation error. **Important thing to note here is we have the correct number of distinct ProviderIDs so it's also not a duplicate issue, wrong joins, or anything like that.** 