### PR TITLE
base.clientproductentitytodisplaypartnerphone

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/BASE.CLIENTPRODUCTENTITYTODISPLAYPARTNERPHONE-report.md
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/BASE.CLIENTPRODUCTENTITYTODISPLAYPARTNERPHONE-report.md
@@ -1,0 +1,45 @@
+# BASE.CLIENTPRODUCTENTITYTODISPLAYPARTNERPHONE Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/7).
+Percentage of Different Columns: 0.00% (0/7).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 7
+- Snowflake: 7
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 2299
+- Snowflake: 507
+- Rows Margin (%): 77.9469334493258
+
+### 2.3 Nulls per Column
+|    | Column_Name                                |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:-------------------------------------------|------------------------:|------------------------:|-------------:|
+|  0 | ClientProductEntityToDisplayPartnerPhoneID |                       0 |                       0 |            0 |
+|  1 | ClientProductToEntityID                    |                       0 |                       0 |            0 |
+|  2 | DisplayPartnerCode                         |                       0 |                       0 |            0 |
+|  3 | PhoneTypeID                                |                       0 |                       0 |            0 |
+|  4 | PhoneNumber                                |                       0 |                       0 |            0 |
+|  5 | SourceCode                                 |                       0 |                       0 |            0 |
+|  6 | LastUpdateDate                             |                       0 |                       0 |            0 |
+
+### 2.4 Distincts per Column
+|    | Column_Name                                |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:-------------------------------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ClientProductEntityToDisplayPartnerPhoneID |                        2299 |                         507 |         77.9 |
+|  1 | ClientProductToEntityID                    |                         146 |                          34 |         76.7 |
+|  2 | DisplayPartnerCode                         |                           1 |                           1 |          0   |
+|  3 | PhoneTypeID                                |                          32 |                          32 |          0   |
+|  4 | PhoneNumber                                |                         146 |                          34 |         76.7 |
+|  5 | SourceCode                                 |                           1 |                           9 |        800   |
+|  6 | LastUpdateDate                             |                          11 |                          10 |          9.1 |

--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/spu_translated_ClientProductEntityToDisplayPartnerPhone.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/spu_translated_ClientProductEntityToDisplayPartnerPhone.sql
@@ -870,13 +870,13 @@ cte_swimlane as (
     
     merge_statement_1:= '     merge into base.clientproductentitytodisplaypartnerphone as target using 
                    (' || select_statement_1 || ') as source on 
-                   source.clientproducttoentityid = target.clientproducttoentityid and  source.phonetypeid = target.phonetypeid 
+                   source.clientproducttoentityid = target.clientproducttoentityid and  source.phonetypeid = target.phonetypeid and source.phonenumber = target.phonenumber and source.displaypartnercode = target.displaypartnercode
                     when matched then' || update_statement || '
                     when not matched then' || insert_statement;
                     
     merge_statement_2:= '     merge into base.clientproductentitytodisplaypartnerphone as target using 
                    (' || select_statement_2 || ') as source on 
-                    source.clientproducttoentityid = target.clientproducttoentityid and  source.phonetypeid = target.phonetypeid
+                    source.clientproducttoentityid = target.clientproducttoentityid and  source.phonetypeid = target.phonetypeid and source.phonenumber = target.phonenumber and source.displaypartnercode = target.displaypartnercode
                     when matched then' || update_statement || '
                     when not matched then' || insert_statement;
                     

--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/spu_translated_ClientProductEntityToDisplayPartnerPhone.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/spu_translated_ClientProductEntityToDisplayPartnerPhone.sql
@@ -38,14 +38,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
     --- select Statement
     -- if no conditionals:
     select_statement_1:= $$  with cte_swimlane as (
-        select
-            *
-        from
-            base.vw_swimlane_base_client qualify dense_rank() over(
-                partition by customerproductcode
-                order by
-                    LastUpdateDate
-            ) = 1
+        select *
+        from base.vw_swimlane_base_client 
+        qualify dense_rank() over(partition by customerproductcodeorder by LastUpdateDate) = 1
     ),
     
     CTE_Display_Partner AS (
@@ -429,7 +424,7 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             PhonePTDPPNP is not null
     )
     select
-        distinct cpte.clientproducttoentityid,
+        cpte.clientproducttoentityid,
         s.displaypartnercode,
         pt.phonetypeid,
         s.phonenumber,
@@ -824,7 +819,7 @@ cte_swimlane as (
             PhonePTFDPPNP is not null
             
     )    
-    select distinct 
+    select  
         cpe.clientproducttoentityid, 
         s.displaypartnercode, 
         pt.phonetypeid, 

--- a/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/spu_translated_ClientProductEntityToDisplayPartnerPhone.sql
+++ b/migration_original/ODS1Stage/tables/Base/ClientProductEntityToDisplayPartnerPhone/spu_translated_ClientProductEntityToDisplayPartnerPhone.sql
@@ -31,13 +31,13 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
     execution_start datetime default getdate();
 
     begin 
+    
     ---------------------------------------------------------
     ----------------- 3. SQL Statements ---------------------
     ---------------------------------------------------------
     --- select Statement
     -- if no conditionals:
-    select_statement_1:= $$
-            with cte_swimlane as (
+    select_statement_1:= $$  with cte_swimlane as (
         select
             *
         from
@@ -47,10 +47,44 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
                     LastUpdateDate
             ) = 1
     ),
+    
+    CTE_Display_Partner AS (
+        SELECT
+            p.ref_customer_product_code AS customerproductcode,
+            TO_VARCHAR(json.value: DISPLAY_PARTNER_CODE) AS DisplayPartner_refDisplayPartnerCode,
+            TO_VARCHAR(json.value: PHONE_PTDES) AS DisplayPartner_PhonePtdes,
+            TO_VARCHAR(json.value: PHONE_PTDESM) AS DisplayPartner_PhonePtdesm,
+            TO_VARCHAR(json.value: PHONE_PTDEST) AS DisplayPartner_PhonePtdest,
+            TO_VARCHAR(json.value: PHONE_PTMTR) AS DisplayPartner_PhonePtmtr,
+            TO_VARCHAR(json.value: PHONE_PTMTRM) AS DisplayPartner_PhonePtmtrm,
+            TO_VARCHAR(json.value: PHONE_PTMTRT) AS DisplayPartner_PhonePtmtrt,
+            TO_VARCHAR(json.value: PHONE_PTMWC) AS DisplayPartner_PhonePtmwc,
+            TO_VARCHAR(json.value: PHONE_PTMWCM) AS DisplayPartner_PhonePtmwcm,
+            TO_VARCHAR(json.value: PHONE_PTMWCT) AS DisplayPartner_PhonePtmwct,
+            TO_VARCHAR(json.value: PHONE_PTPSR) AS DisplayPartner_PhonePtpsr,
+            TO_VARCHAR(json.value: PHONE_PTPSRM) AS DisplayPartner_PhonePtpsrm,
+            TO_VARCHAR(json.value: PHONE_PTPSRT) AS DisplayPartner_PhonePtPsrt,
+            TO_VARCHAR(json.value: PHONE_PTHOS) AS DisplayPartner_PhonePtHos,
+            TO_VARCHAR(json.value: PHONE_PTHOSM) AS DisplayPartner_PhonePtHosM,
+            TO_VARCHAR(json.value: PHONE_PTHOST) AS DisplayPartner_PhonePtHost,
+            TO_VARCHAR(json.value: PHONE_PTPSRD) AS DisplayPartner_PhonePtPsrd,
+            TO_VARCHAR(json.value: PHONE_PTEMP) AS DisplayPartner_PhonePtEmp,
+            TO_VARCHAR(json.value: PHONE_PTEMPM) AS DisplayPartner_PhonePtEmpM,
+            TO_VARCHAR(json.value: PHONE_PTEMPT) AS DisplayPartner_PhonePtEmpt,
+            TO_VARCHAR(json.value: PHONE_PTDPPEP) AS DisplayPartner_PhonePtDpPep,
+            TO_VARCHAR(json.value: PHONE_PTDPPNP) AS DisplayPartner_PhonePtDpPnp,
+            TO_VARCHAR(json.value: DATA_SOURCE_CODE) AS DisplayPartner_SourceCode,
+            TO_TIMESTAMP_NTZ(json.value: UPDATED_DATETIME) AS DisplayPartner_LastUpdateDate
+        FROM mdm_team.mst.customer_product_profile_processing AS p,
+             LATERAL FLATTEN(input => p.CUSTOMER_PRODUCT_PROFILE:DISPLAY_PARTNER) AS json
+    ),
+    
     CTE_SwimlanePhones as (
         select
             s.customerproductcode as ClientToProductcode,
             s.productcode,
+            json.displaypartner_sourcecode as sourcecode,
+            json.displaypartner_lastupdatedate as lastupdatedate,
             json.displaypartner_REFDISPLAYPARTNERCODE as DisplayPartnerCode,
             CASE
                 WHEN s.productcode = 'MAP' then null
@@ -138,15 +172,17 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             END as PhonePTDPPNP
         from
             CTE_swimlane as S
-            left join raw.vw_CUSTOMER_PRODUCT_PROFILE as JSON on json.customerproductcode = s.customerproductcode
-            inner join base.syndicationpartner as SP on sp.syndicationpartnercode = json.displaypartner_REFDISPLAYPARTNERCODE
+            join cte_display_partner as JSON on json.customerproductcode = s.customerproductcode
+            join base.syndicationpartner as SP on sp.syndicationpartnercode = json.displaypartner_REFDISPLAYPARTNERCODE
     ),
     cte_tmp_phones as (
         select
             ClientToProductCode,
             DisplayPartnerCode,
             'PTDES' as PhoneTypeCode,
-            PhonePTDES as PhoneNumber
+            PhonePTDES as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -156,7 +192,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTDESM' as PhoneTypeCode,
-            PhonePTDESM as PhoneNumber
+            PhonePTDESM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -166,7 +204,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTDEST' as PhoneTypeCode,
-            PhonePTDEST as PhoneNumber
+            PhonePTDEST as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -176,7 +216,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTEMP' as PhoneTypeCode,
-            PhonePTEMP as PhoneNumber
+            PhonePTEMP as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -186,7 +228,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTEMPM' as PhoneTypeCode,
-            PhonePTEMPM as PhoneNumber
+            PhonePTEMPM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -196,7 +240,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTEMPT' as PhoneTypeCode,
-            PhonePTEMPT as PhoneNumber
+            PhonePTEMPT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -206,7 +252,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTHOS' as PhoneTypeCode,
-            PhonePTHOS as PhoneNumber
+            PhonePTHOS as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -216,7 +264,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTHOSM' as PhoneTypeCode,
-            PhonePTHOSM as PhoneNumber
+            PhonePTHOSM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -226,7 +276,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTHOST' as PhoneTypeCode,
-            PhonePTHOST as PhoneNumber
+            PhonePTHOST as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -236,7 +288,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTMTR' as PhoneTypeCode,
-            PhonePTMTR as PhoneNumber
+            PhonePTMTR as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -246,7 +300,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTMTRT' as PhoneTypeCode,
-            PhonePTMTRT as PhoneNumber
+            PhonePTMTRT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -256,7 +312,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTMTRM' as PhoneTypeCode,
-            PhonePTMTRM as PhoneNumber
+            PhonePTMTRM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -266,7 +324,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTMWC' as PhoneTypeCode,
-            PhonePTMWC as PhoneNumber
+            PhonePTMWC as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -276,7 +336,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTMWCT' as PhoneTypeCode,
-            PhonePTMWCT as PhoneNumber
+            PhonePTMWCT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -286,7 +348,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTMWCM' as PhoneTypeCode,
-            PhonePTMWCM as PhoneNumber
+            PhonePTMWCM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -296,7 +360,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTPSR' as PhoneTypeCode,
-            PhonePTPSR as PhoneNumber
+            PhonePTPSR as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -306,7 +372,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTPSRD' as PhoneTypeCode,
-            PhonePTPSRD as PhoneNumber
+            PhonePTPSRD as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -316,7 +384,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTPSRM' as PhoneTypeCode,
-            PhonePTPSRM as PhoneNumber
+            PhonePTPSRM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -326,7 +396,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTPSRT' as PhoneTypeCode,
-            PhonePTPSRT as PhoneNumber
+            PhonePTPSRT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -336,7 +408,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTDPPEP' as PhoneTypeCode,
-            PhonePTDPPEP as PhoneNumber
+            PhonePTDPPEP as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -346,7 +420,9 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
             ClientToProductCode,
             DisplayPartnerCode,
             'PTDPPNP' as PhoneTypeCode,
-            PhonePTDPPNP as PhoneNumber
+            PhonePTDPPNP as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SwimlanePhones
         where
@@ -357,8 +433,8 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
         s.displaypartnercode,
         pt.phonetypeid,
         s.phonenumber,
-        'Profisee' as SourceCode,
-        sysdate() as LastUpdateDate
+        ifnull( s.sourcecode, 'Profisee') as SourceCode,
+        ifnull( s.lastupdatedate, sysdate()) as LastUpdateDate
     from
         cte_tmp_phones s
         inner join base.entitytype as et on et.entitytypecode = 'CLPROD'
@@ -367,59 +443,104 @@ CREATE or REPLACE PROCEDURE BASE.SP_LOAD_ClientProductEntityToDisplayPartnerPhon
         inner join base.clientproducttoentity as CPtE on cpte.clienttoproductid = ctp.clienttoproductid
         and cpte.entitytypeid = et.entitytypeid
     where
-        s.displaypartnercode != 'HG' $$;
-select_statement_2:= $$     with cte_swimlane as (
+        s.displaypartnercode != 'HG'
+    qualify row_number() over(partition by clientproducttoentityid, phonetypeid order by s.lastupdatedate desc) = 1 $$;
+
+        
+select_statement_2:= $$  with CTE_Customer_Product AS (
+    SELECT
+        f.ref_facility_code AS facilitycode,
+        TO_VARCHAR(json.value: CUSTOMER_PRODUCT_CODE) AS CustomerProduct_CustomerProductCode,
+        TO_VARCHAR(json.value: FEATURE_FCCLLOGO) AS CustomerProduct_FeatureFcclLogo,
+        TO_VARCHAR(json.value: FEATURE_FCCLURL) AS CustomerProduct_FeatureFcclUrl,
+        TO_TIMESTAMP_NTZ(json.value: DESIGNATED_DATETIME) AS CustomerProduct_DesignatedDatetime,
+        TO_VARCHAR(json.value: FEATURE_FCFLOGO) AS CustomerProduct_FeatureFcfLogo,
+        TO_VARCHAR(json.value: FEATURE_FCFURL) AS CustomerProduct_FeatureFcfUrl,
+        TO_VARCHAR(json.value: OPT_OUT) AS CustomerProduct_OptOut,
+        TO_VARCHAR(json.value: DATA_SOURCE_CODE) AS CustomerProduct_SourceCode,
+        TO_TIMESTAMP_NTZ(json.value: UPDATED_DATETIME) AS CustomerProduct_LastUpdateDate,
+        TO_JSON(json.value: DISPLAY_PARTNER) AS customerproduct_displaypartner
+    FROM mdm_Team.mst.facility_profile_processing AS f,
+         LATERAL FLATTEN(input => f.FACILITY_PROFILE:CUSTOMER_PRODUCT) AS json
+),
+
+cte_swimlane as (
         select
             facilityid as FacilityID,
-            vfp.facilitycode as FacilityCode,
+            vfp.FacilityCode,
             cp.clienttoproductid,
             customerproduct_customerproductcode as ClientToProductCode,
             parse_json(customerproduct_displaypartner) as DisplayPartner,
             customerproduct_featurefcclurl,
             customerproduct_featurefcflogo,
             customerproduct_featurefcfurl,
-            row_number() over(
-                partition by FacilityID
-                order by
-                    CREATE_DATE desc
-            ) as RowRank,
-            'Reltio' as SourceCode,
-            sysdate() as LastUpdateDate
+            ifnull(customerproduct_sourcecode, 'Reltio') as SourceCode,
+            ifnull(customerproduct_lastupdatedate, sysdate()) as LastUpdateDate
         from
-            raw.vw_facility_profile as vfp
+            cte_customer_product as vfp
             join base.facility as f on vfp.facilitycode = f.facilitycode
             join base.clienttoproduct as cp on cp.clienttoproductcode = vfp.customerproduct_customerproductcode
-        where
-            customerproduct_customerproductcode is not null
     ),
+    cte_display_partner as 
+            (SELECT
+                s.facilitycode,
+                s.clienttoproductcode,
+                s.lastupdatedate,
+                s.sourcecode,
+                to_varchar(json.value:DISPLAY_PARTNER_CODE) as DisplayPartnerCode,
+                to_varchar(json.value:PHONE_PTFDS) as PhonePTFDS,
+                to_varchar(json.value:PHONE_PTFDSM) as PhonePTFDSM,
+                to_varchar(json.value:PHONE_PTFDST) as PhonePTFDST,
+                to_varchar(json.value:PHONE_PTFMC) as PhonePTFMC,
+                to_varchar(json.value:PHONE_PTFMCM) as PhonePTFMCM,
+                to_varchar(json.value:PHONE_PTFMCT) as PhonePTFMCT,
+                to_varchar(json.value:PHONE_PTFMT) as PhonePTFMT,
+                to_varchar(json.value:PHONE_PTFMTM) as PhonePTFMTM,
+                to_varchar(json.value:PHONE_PTFMTT) as PhonePTFMTT,
+                to_varchar(json.value:PHONE_PTFSR) as PhonePTFSR,
+                to_varchar(json.value:PHONE_PTFSRD) as PhonePTFSRD,
+                to_varchar(json.value:PHONE_PTFSRDM) as PhonePTFSRDM,
+                to_varchar(json.value:PHONE_PTFSRM) as PhonePTFSRM,
+                to_varchar(json.value:PHONE_PTFSRT) as PhonePTFSRT,
+                to_varchar(json.value:PHONE_PTHFS) as PhonePTHFS,
+                to_varchar(json.value:PHONE_PTHFSM) as PhonePTHFSM,
+                to_varchar(json.value:PHONE_PTHFST) as PhonePTHFST,
+                to_varchar(json.value:PHONE_PTUFS) as PhonePTUFS,
+                to_varchar(json.value:PHONE_PTFDPPEP) as PhonePTFDPPEP,
+                to_varchar(json.value:PHONE_PTFDPPNP) as PhonePTFDPPNP
+            FROM cte_swimlane as s
+            , lateral flatten(input => s.displaypartner) as json
+    ),
+        
     cte_swimlane_phones as (
         select
             cte.facilitycode,
             cte.clienttoproductcode,
-            cte.rowrank,
-            DisplayPartner:DISPLAY_PARTNER_CODE as DisplayPartnerCode,
-            DisplayPartner:PHONE_PTFDS as PhonePTFDS,
-            DisplayPartner:PHONE_PTFDSM as PhonePTFDSM,
-            DisplayPartner:PHONE_PTFDST as PhonePTFDST,
-            DisplayPartner:PHONE_PTFMC as PhonePTFMC,
-            DisplayPartner:PHONE_PTFMCM as PhonePTFMCM,
-            DisplayPartner:PHONE_PTFMCT as PhonePTFMCT,
-            DisplayPartner:PHONE_PTFMT as PhonePTFMT,
-            DisplayPartner:PHONE_PTFMTM as PhonePTFMTM,
-            DisplayPartner:PHONE_PTFMTT as PhonePTFMTT,
-            DisplayPartner:PHONE_PTFSR as PhonePTFSR,
-            DisplayPartner:PHONE_PTFSRD as PhonePTFSRD,
-            DisplayPartner:PHONE_PTFSRDM as PhonePTFSRDM,
-            DisplayPartner:PHONE_PTFSRM as PhonePTFSRM,
-            DisplayPartner:PHONE_PTFSRT as PhonePTFSRT,
-            DisplayPartner:PHONE_PTHFS as PhonePTHFS,
-            DisplayPartner:PHONE_PTHFSM as PhonePTHFSM,
-            DisplayPartner:PHONE_PTHFST as PhonePTHFST,
-            DisplayPartner:PHONE_PTUFS as PhonePTUFS,
-            DisplayPartner:PHONE_PTFDPPEP as PhonePTFDPPEP,
-            DisplayPartner:PHONE_PTFDPPNP as PhonePTFDPPNP
+            cte.DisplayPartnerCode,
+            cte.PhonePTFDS,
+            cte.PhonePTFDSM,
+            cte.PhonePTFDST,
+            cte.PhonePTFMC,
+            cte.PhonePTFMCM,
+            cte.PhonePTFMCT,
+            cte.PhonePTFMT,
+            cte.PhonePTFMTM,
+            cte.PhonePTFMTT,
+            cte.PhonePTFSR,
+            cte.PhonePTFSRD,
+            cte.PhonePTFSRDM,
+            cte.PhonePTFSRM,
+            cte.PhonePTFSRT,
+            cte.PhonePTHFS,
+            cte.PhonePTHFSM,
+            cte.PhonePTHFST,
+            cte.PhonePTUFS,
+            cte.PhonePTFDPPEP,
+            cte.PhonePTFDPPNP,
+            cte.lastupdatedate,
+            cte.sourcecode
         from
-            cte_swimlane as cte
+            cte_display_partner as cte
             join base.syndicationpartner as sp on sp.syndicationpartnercode = DisplayPartnerCode
     ),
     cte_tmp_phones as (
@@ -428,248 +549,288 @@ select_statement_2:= $$     with cte_swimlane as (
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFDS' as PhoneTypeCode,
-            PhonePTFDS as PhoneNumber
+            PhonePTFDS as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFDS is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFDSM' as PhoneTypeCode,
-            PhonePTFDSM as PhoneNumber
+            PhonePTFDSM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFDSM is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFDST' as PhoneTypeCode,
-            PhonePTFDST as PhoneNumber
+            PhonePTFDST as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFDST is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFMC' as PhoneTypeCode,
-            PhonePTFMC as PhoneNumber
+            PhonePTFMC as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFMC is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFMCM' as PhoneTypeCode,
-            PhonePTFMCM as PhoneNumber
+            PhonePTFMCM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFMCM is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFMCT' as PhoneTypeCode,
-            PhonePTFMCT as PhoneNumber
+            PhonePTFMCT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFMCT is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFMT' as PhoneTypeCode,
-            PhonePTFMT as PhoneNumber
+            PhonePTFMT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFMT is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFMTM' as PhoneTypeCode,
-            PhonePTFMTM as PhoneNumber
+            PhonePTFMTM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFMTM is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFMTT' as PhoneTypeCode,
-            PhonePTFMTT as PhoneNumber
+            PhonePTFMTT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFMTT is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFSR' as PhoneTypeCode,
-            PhonePTFSR as PhoneNumber
+            PhonePTFSR as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFSR is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFSRD' as PhoneTypeCode,
-            PhonePTFSRD as PhoneNumber
+            PhonePTFSRD as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFSRD is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFSRDM' as PhoneTypeCode,
-            PhonePTFSRDM as PhoneNumber
+            PhonePTFSRDM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFSRDM is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFSRM' as PhoneTypeCode,
-            PhonePTFSRM as PhoneNumber
+            PhonePTFSRM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFSRM is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFSRT' as PhoneTypeCode,
-            PhonePTFSRT as PhoneNumber
+            PhonePTFSRT as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFSRT is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTHFS' as PhoneTypeCode,
-            PhonePTHFS as PhoneNumber
+            PhonePTHFS as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTHFS is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTHFSM' as PhoneTypeCode,
-            PhonePTHFSM as PhoneNumber
+            PhonePTHFSM as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTHFSM is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTHFST' as PhoneTypeCode,
-            PhonePTHFST as PhoneNumber
+            PhonePTHFST as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTHFST is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTUFS' as PhoneTypeCode,
-            PhonePTUFS as PhoneNumber
+            PhonePTUFS as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTUFS is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFDPPEP' as PhoneTypeCode,
-            PhonePTFDPPEP as PhoneNumber
+            PhonePTFDPPEP as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFDPPEP is not null
-            and RowRank = 1
+            
         union all
         select
             FacilityCode,
             ClientToProductCode,
             DisplayPartnerCode,
             'PTFDPPNP' as PhoneTypeCode,
-            PhonePTFDPPNP as PhoneNumber
+            PhonePTFDPPNP as PhoneNumber,
+            sourcecode,
+            lastupdatedate
         from
             CTE_SWIMLANE_PHONES
         where
             PhonePTFDPPNP is not null
-            and RowRank = 1
+            
     )    
     select distinct 
         cpe.clientproducttoentityid, 
         s.displaypartnercode, 
         pt.phonetypeid, 
         s.phonenumber, 
-        'Profisee' as SourceCode, 
-        sysdate() as LastUpdateDate
+        ifnull(s.sourcecode, 'Profisee') as SourceCode, 
+        ifnull(s.lastupdatedate, sysdate()) as LastUpdateDate
     from cte_tmp_phones as s
         join base.entitytype b
         on b.entitytypecode='FAC'
@@ -677,32 +838,53 @@ select_statement_2:= $$     with cte_swimlane as (
         join base.clienttoproduct as cp on cp.clienttoproductcode = s.clienttoproductcode
         join base.clientproducttoentity cpe on f.facilityid = cpe.entityid and b.entitytypeid = cpe.entitytypeid and cp.clienttoproductid = cpe.clienttoproductid
         join base.phonetype as pt on pt.phonetypecode = s.phonetypecode
-    where s.displaypartnercode != 'HG'$$;
+    where s.displaypartnercode != 'HG'
+    qualify row_number() over(partition by clientproducttoentityid, phonetypeid order by s.lastupdatedate desc) = 1 $$;
+    
     --- update Statement
     update_statement:= '
         update
         SET
+            displaypartnercode = source.displaypartnercode,
+            phonenumber = source.phonenumber,
             SourceCode = source.sourcecode,
             LastUpdateDate = source.lastupdatedate';
+            
     --- insert Statement
     insert_statement:= ' 
-                insert(clientproductentitytodisplaypartnerphoneid,ClientProductToEntityID,DisplayPartnerCode,PhoneTypeID,PhoneNumber,SourceCode,LastUpdateDate)
-                values(uuid_string(),ClientProductToEntityID,DisplayPartnerCode,PhoneTypeID,PhoneNumber,SourceCode,LastUpdateDate)';
+                insert(
+                    clientproductentitytodisplaypartnerphoneid,
+                    ClientProductToEntityID,
+                    DisplayPartnerCode,
+                    PhoneTypeID,
+                    PhoneNumber,
+                    SourceCode,
+                    LastUpdateDate)
+                values(
+                    uuid_string(),
+                    ClientProductToEntityID,
+                    DisplayPartnerCode,
+                    PhoneTypeID,
+                    PhoneNumber,
+                    SourceCode,
+                    LastUpdateDate)';
+                    
     ---------------------------------------------------------
     --------- 4. actions (inserts and updates) --------------
     ---------------------------------------------------------
+    
     merge_statement_1:= '     merge into base.clientproductentitytodisplaypartnerphone as target using 
-                   (' || select_statement_1 || ') as source on source.clientproducttoentityid = target.clientproducttoentityid and 
-                   source.phonetypeid = target.phonetypeid and source.phonenumber = target.phonenumber and 
-                   source.displaypartnercode = target.displaypartnercode
-                    WHEN MATCHED then' || update_statement || '
+                   (' || select_statement_1 || ') as source on 
+                   source.clientproducttoentityid = target.clientproducttoentityid and  source.phonetypeid = target.phonetypeid 
+                    when matched then' || update_statement || '
                     when not matched then' || insert_statement;
-merge_statement_2:= '     merge into base.clientproductentitytodisplaypartnerphone as target using 
-                   (' || select_statement_2 || ') as source on source.clientproducttoentityid = target.clientproducttoentityid and 
-                   source.phonetypeid = target.phonetypeid and source.phonenumber = target.phonenumber and 
-                   source.displaypartnercode = target.displaypartnercode
-                    WHEN MATCHED then' || update_statement || '
+                    
+    merge_statement_2:= '     merge into base.clientproductentitytodisplaypartnerphone as target using 
+                   (' || select_statement_2 || ') as source on 
+                    source.clientproducttoentityid = target.clientproducttoentityid and  source.phonetypeid = target.phonetypeid
+                    when matched then' || update_statement || '
                     when not matched then' || insert_statement;
+                    
     ---------------------------------------------------------
     ------------------- 5. execution ------------------------
     ---------------------------------------------------------
@@ -710,7 +892,6 @@ merge_statement_2:= '     merge into base.clientproductentitytodisplaypartnerpho
     if (is_full) then
         truncate table base.clientproductentitytodisplaypartnerphone;
     end if; 
-    -- execute immediate update_statement;
     execute immediate merge_statement_1;
     execute immediate merge_statement_2;
     ---------------------------------------------------------


### PR DESCRIPTION
The number of rows does not match because other ids have been influenced and we have less clientproducttoentityids which gives less combinations. Also, the main id of the table was not a uuid but an auto increment. We have changed it to a uuid in snowflake to keep the same format for all tables