### PR TITLE
Mid.ProviderCondition Validation

### DIFF
--- a/migration_original/ODS1Stage/tables/Mid/ProviderCondition/MID.PROVIDERCONDITION-report.md
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderCondition/MID.PROVIDERCONDITION-report.md
@@ -1,0 +1,43 @@
+# MID.PROVIDERCONDITION Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/6).
+Percentage of Different Columns: 0.00% (0/6).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+| Column Name   | Match ID   | SQL Server Value   | Snowflake Value   |
+|---------------|------------|--------------------|-------------------|
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 6
+- Snowflake: 6
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 74853051
+- Snowflake: 93780846
+- Rows Margin (%): 25.286604550026958
+
+### 2.3 Nulls per Column
+|    | Column_Name               |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:--------------------------|------------------------:|------------------------:|-------------:|
+|  0 | ProviderToConditionID     |                       0 |                       0 |          0   |
+|  1 | ProviderID                |                       0 |                       0 |          0   |
+|  2 | ConditionCode             |                       0 |                       0 |          0   |
+|  3 | ConditionDescription      |                       0 |                       0 |          0   |
+|  4 | ConditionGroupDescription |                74853051 |                93780846 |         25.3 |
+|  5 | LegacyKey                 |                72533458 |                90869675 |         25.3 |
+
+### 2.4 Distincts per Column
+|    | Column_Name               |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:--------------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ProviderToConditionID     |                    74853051 |                    82977422 |         10.9 |
+|  1 | ProviderID                |                     1078743 |                     1114125 |          3.3 |
+|  2 | ConditionCode             |                        8909 |                        8911 |          0   |
+|  3 | ConditionDescription      |                        8909 |                        8911 |          0   |
+|  4 | ConditionGroupDescription |                           0 |                           0 |          0   |
+|  5 | LegacyKey                 |                          95 |                          95 |          0   |

--- a/migration_original/ODS1Stage/tables/Mid/ProviderCondition/spu_translated_ProviderCondition.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderCondition/spu_translated_ProviderCondition.sql
@@ -40,9 +40,8 @@ begin
                                 select
                                     p.providerid
                                 from
-                                    $$ || mdm_db || $$.mst.Provider_Profile_Processing as ppp
-                                    join base.provider as P on p.providercode = ppp.ref_provider_code
-                                order by pdp.providerid
+                                    $$||mdm_db||$$.mst.Provider_Profile_Processing as ppp
+                                join base.provider as P on p.providercode = ppp.ref_provider_code
                             ),
                             
                             CTE_ProviderCondition as (
@@ -59,7 +58,7 @@ begin
                                 inner join base.entitytype as et on et.entitytypeid = etmt.entitytypeid
                                 inner join base.medicaltermset as mts on mts.medicaltermsetid = mt.medicaltermsetid
                                 inner join base.medicaltermtype as mtt on mtt.medicaltermtypeid = mt.medicaltermtypeid
-                                inner join mid.providercondition as mpc on etmt.entitytomedicaltermid = mpc.providertoconditionid
+                                left join mid.providercondition as mpc on etmt.entitytomedicaltermid = mpc.providertoconditionid
                                 where mts.medicaltermsetcode = 'HGProvider' and mtt.medicaltermtypecode = 'Condition'
                                  and (MD5(ifnull(CAST(mt.medicaltermcode as varchar), '')) <> MD5(ifnull(CAST(mpc.conditioncode as varchar), '')) or 
                                       MD5(ifnull(CAST(mt.medicaltermdescription1 as varchar), '')) <> MD5(ifnull(CAST(mpc.conditiondescription as varchar), '')) or 


### PR DESCRIPTION
Fixed minor bugs: wrong alias, deleted an unnecessary order by (why sort in a transactional workload), and changed inner join with the table itself to a left join because in full refresh after truncating that inner join caused 0 rows in select statement. 

We have more rows in Snowflake but this is a relatively simple select statement and we also have more providers so it's likely due to that.