### PR TITLE
Mid.ProviderSpecialtyFacilityServiceLineRating

### DIFF
--- a/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/MID.PROVIDERSPECIALTYFACILITYSERVICELINERATING-report.md
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/MID.PROVIDERSPECIALTYFACILITYSERVICELINERATING-report.md
@@ -1,0 +1,52 @@
+# MID.PROVIDERSPECIALTYFACILITYSERVICELINERATING Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 0.00% (0/7).
+Percentage of Different Columns: 100.00% (7/7).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+|    | Column Name            | Match ID   | SQL Server Value                     | Snowflake Value                      |
+|---:|:-----------------------|:-----------|:-------------------------------------|:-------------------------------------|
+|  0 | PROVIDERID             | SLORT      | 32575155-5232-0000-0000-000000000000 | 95f33244-b006-480c-bea0-b49bddd47d4d |
+|  1 | SERVICELINECODE        | SLORT      | SLORT                                | SLNSC                                |
+|  2 | SERVICELINESTAR        | SLORT      | 5                                    | 1                                    |
+|  3 | SERVICELINEDESCRIPTION | SLORT      | Orthopedic                           | Neurosciences                        |
+|  4 | LEGACYKEY              | SLORT      | 31                                   | HGST77346F56140191                   |
+|  5 | SPECIALTYID            | SLORT      | 5253524f-0000-0000-0000-000000000000 | 5255454e-0000-0000-0000-000000000000 |
+|  6 | SPECIALTYCODE          | SLORT      | ORSR                                 | NEUR                                 |
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 7
+- Snowflake: 7
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 267934
+- Snowflake: 27984
+- Rows Margin (%): 89.55563683593721
+
+### 2.3 Nulls per Column
+|    | Column_Name            |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:-----------------------|------------------------:|------------------------:|-------------:|
+|  0 | ProviderID             |                       0 |                       0 |            0 |
+|  1 | ServiceLineCode        |                       0 |                       0 |            0 |
+|  2 | ServiceLineStar        |                       0 |                       0 |            0 |
+|  3 | ServiceLineDescription |                       0 |                       0 |            0 |
+|  4 | LegacyKey              |                       0 |                       0 |            0 |
+|  5 | SpecialtyID            |                       0 |                       0 |            0 |
+|  6 | SpecialtyCode          |                       0 |                       0 |            0 |
+
+### 2.4 Distincts per Column
+|    | Column_Name            |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:-----------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | ProviderID             |                      187671 |                       13792 |         92.7 |
+|  1 | ServiceLineCode        |                          15 |                          14 |          6.7 |
+|  2 | ServiceLineStar        |                           3 |                           3 |          0   |
+|  3 | ServiceLineDescription |                          15 |                          14 |          6.7 |
+|  4 | LegacyKey              |                          24 |                        1820 |       7483.3 |
+|  5 | SpecialtyID            |                          24 |                          23 |          4.2 |
+|  6 | SpecialtyCode          |                          24 |                          23 |          4.2 |

--- a/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/MID.PROVIDERSPECIALTYFACILITYSERVICELINERATING-report.md
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/MID.PROVIDERSPECIALTYFACILITYSERVICELINERATING-report.md
@@ -9,13 +9,13 @@ The example below shows a sample row where values are not identical. Important t
 
 |    | Column Name            | Match ID   | SQL Server Value                     | Snowflake Value                      |
 |---:|:-----------------------|:-----------|:-------------------------------------|:-------------------------------------|
-|  0 | PROVIDERID             | SLORT      | 32575155-5232-0000-0000-000000000000 | 95f33244-b006-480c-bea0-b49bddd47d4d |
-|  1 | SERVICELINECODE        | SLORT      | SLORT                                | SLNSC                                |
-|  2 | SERVICELINESTAR        | SLORT      | 5                                    | 1                                    |
-|  3 | SERVICELINEDESCRIPTION | SLORT      | Orthopedic                           | Neurosciences                        |
-|  4 | LEGACYKEY              | SLORT      | 31                                   | HGST77346F56140191                   |
-|  5 | SPECIALTYID            | SLORT      | 5253524f-0000-0000-0000-000000000000 | 5255454e-0000-0000-0000-000000000000 |
-|  6 | SPECIALTYCODE          | SLORT      | ORSR                                 | NEUR                                 |
+|  0 | PROVIDERID             | SLPRS      | 424c4c55-5433-0000-0000-000000000000 | 764a5637-c9c2-4332-8090-ae6d9bcd9ed7 |
+|  1 | SERVICELINECODE        | SLPRS      | SLPRS                                | SLNSC                                |
+|  2 | SERVICELINESTAR        | SLPRS      | 1                                    | 5                                    |
+|  3 | SERVICELINEDESCRIPTION | SLPRS      | Prostate Surgery                     | Neurosciences                        |
+|  4 | LEGACYKEY              | SLPRS      | 64                                   | 28                                   |
+|  5 | SPECIALTYID            | SLPRS      | 4c4f5255-0000-0000-0000-000000000000 | 5255454e-0000-0000-0000-000000000000 |
+|  6 | SPECIALTYCODE          | SLPRS      | UROL                                 | NEUR                                 |
 
 ## 2. Aggregate Validation
 
@@ -26,8 +26,8 @@ The example below shows a sample row where values are not identical. Important t
 
 ### 2.2 Total Rows
 - SQL Server: 267934
-- Snowflake: 27984
-- Rows Margin (%): 89.55563683593721
+- Snowflake: 20418
+- Rows Margin (%): 92.37946658505453
 
 ### 2.3 Nulls per Column
 |    | Column_Name            |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
@@ -47,6 +47,6 @@ The example below shows a sample row where values are not identical. Important t
 |  1 | ServiceLineCode        |                          15 |                          14 |          6.7 |
 |  2 | ServiceLineStar        |                           3 |                           3 |          0   |
 |  3 | ServiceLineDescription |                          15 |                          14 |          6.7 |
-|  4 | LegacyKey              |                          24 |                        1820 |       7483.3 |
+|  4 | LegacyKey              |                          24 |                          23 |          4.2 |
 |  5 | SpecialtyID            |                          24 |                          23 |          4.2 |
 |  6 | SpecialtyCode          |                          24 |                          23 |          4.2 |

--- a/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/spu_translated_ProviderSpecialtyFacilityServiceLineRating.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/spu_translated_ProviderSpecialtyFacilityServiceLineRating.sql
@@ -48,96 +48,48 @@ select_statement := $$ with CTE_ProviderBatch as (
                 from
                     $$ || mdm_db || $$.mst.Provider_Profile_Processing as ppp
                     join base.provider as P on p.providercode = ppp.ref_provider_code),
-                    cte_union as (
-    select
-        fsl.facilityid,
-        fsl.servicelineid,
-        sl.servicelinedescription,
-        fsl.survivalstar as servicelinestar
-    from
-        ermart1.facility_facilitytoservicelinerating as fsl
-        join ermart1.facility_serviceline as sl on fsl.servicelineid = sl.servicelineid
-    where
-        fsl.ismaxyear = 1
-    union all
-    select
-        fpr.facilityid,
-        sl.servicelineid,
-        sl.servicelinedescription,
-        fpr.overallsurvivalstar as servicelinestar
-    from
-        ermart1.facility_facilitytoprocedurerating as fpr
-        join ermart1.facility_proceduretoserviceline as psl on fpr.procedureid = psl.procedureid
-        join ermart1.facility_serviceline as sl on psl.servicelineid = sl.servicelineid
-    where
-        fpr.ismaxyear = 1
-        and fpr.procedureid = 'ob1'
-),
-cte_providerspecialtyfacilityservicelinerating as (
-    select distinct 
-        pb.providerid, 
-        tstslg.servicelinecode, 
-        e.servicelinestar, 
-        e.servicelinedescription, 
-        b.legacykey, 
-        tstslg.specialtyid, 
-        tstslg.specialtycode,
-        0 as actioncode
-    from cte_providerbatch as pb
-    inner join base.providertofacility as pf on pf.providerid = pb.providerid
-    join base.facility as b on pf.facilityid = b.facilityid
-    join base.providertospecialty as ps on pf.providerid = ps.providerid
-    join base.specialtygrouptospecialty as sgs on sgs.specialtyid = ps.specialtyid
-    join base.specialtygroup as sg on sg.specialtygroupid = sgs.specialtygroupid
-    join base.tempspecialtytoservicelineghetto as tstslg on sg.specialtygroupcode = tstslg.specialtycode
-    join cte_union as e on b.legacykey = e.facilityid and tstslg.servicelinecode = 'SL' || e.servicelineid
-    order by pb.providerid
-),
-
--- insert action
-cte_action_1 as (
-    select 
-        cte.providerid, 
-        cte.servicelinecode, 
-        cte.servicelinestar, 
-        cte.servicelinedescription, 
-        cte.legacykey, 
-        cte.specialtyid, 
-        cte.specialtycode,
-        1 as actioncode
-    from cte_providerspecialtyfacilityservicelinerating as cte
-    left join mid.providerspecialtyfacilityservicelinerating as mid
-    on cte.providerid = mid.providerid and cte.specialtycode = mid.specialtycode and cte.servicelinecode = mid.servicelinecode and cte.servicelinestar = mid.servicelinestar
-    where mid.providerid is null
-),
-
--- update action
-cte_action_2 as (
-    select 
-        cte.providerid, 
-        2 as actioncode
-    from cte_providerspecialtyfacilityservicelinerating as cte
-    left join mid.providerspecialtyfacilityservicelinerating as mid
-    on cte.providerid = mid.providerid and cte.specialtycode = mid.specialtycode and cte.servicelinecode = mid.servicelinecode and cte.servicelinestar = mid.servicelinestar
-    where
-         md5(ifnull(cte.servicelinedescription::varchar,'''')) <> md5(ifnull(mid.servicelinedescription::varchar,'''')) or 
-         md5(ifnull(cte.legacykey::varchar,'''')) <> md5(ifnull(mid.legacykey::varchar,'''')) or 
-        md5(ifnull(cte.specialtyid::varchar,'''')) <> md5(ifnull(mid.specialtyid::varchar,'''')) 
-)
-select distinct
-    a0.providerid, 
-    a0.servicelinecode, 
-    a0.servicelinestar, 
-    a0.servicelinedescription, 
-    a0.legacykey, 
-    a0.specialtyid, 
-    a0.specialtycode,
-    ifnull(a1.actioncode, ifnull(a2.actioncode, a0.actioncode)) as ActionCode 
-from cte_providerspecialtyfacilityservicelinerating as a0 
-left join cte_action_1 as a1 on a0.providerid = a1.providerid
-left join cte_action_2 as a2 on a0.providerid = a2.providerid
-where ifnull(a1.actioncode, ifnull(a2.actioncode, a0.actioncode)) <> 0 
-     $$;
+                cte_union as (
+                select
+                    fsl.facilityid,
+                    fsl.servicelineid,
+                    sl.servicelinedescription,
+                    fsl.survivalstar as servicelinestar
+                from
+                    ermart1.facility_facilitytoservicelinerating as fsl
+                    join ermart1.facility_serviceline as sl on fsl.servicelineid = sl.servicelineid
+                where
+                    fsl.ismaxyear = 1
+                union all
+                select
+                    fpr.facilityid,
+                    sl.servicelineid,
+                    sl.servicelinedescription,
+                    fpr.overallsurvivalstar as servicelinestar
+                from
+                    ermart1.facility_facilitytoprocedurerating as fpr
+                    join ermart1.facility_proceduretoserviceline as psl on fpr.procedureid = psl.procedureid
+                    join ermart1.facility_serviceline as sl on psl.servicelineid = sl.servicelineid
+                where
+                    fpr.ismaxyear = 1
+                    and fpr.procedureid = 'ob1')
+                select distinct 
+                    pb.providerid, 
+                    tstslg.servicelinecode, 
+                    e.servicelinestar, 
+                    e.servicelinedescription, 
+                    b.legacykey, 
+                    tstslg.specialtyid, 
+                    tstslg.specialtycode
+                from cte_providerbatch as pb
+                inner join base.providertofacility as pf on pf.providerid = pb.providerid
+                join base.facility as b on pf.facilityid = b.facilityid
+                join base.providertospecialty as ps on pf.providerid = ps.providerid
+                join base.specialtygrouptospecialty as sgs on sgs.specialtyid = ps.specialtyid
+                join base.specialtygroup as sg on sg.specialtygroupid = sgs.specialtygroupid
+                join base.tempspecialtytoservicelineghetto as tstslg on sg.specialtygroupcode = tstslg.specialtycode
+                join cte_union as e on b.legacykey = e.facilityid and tstslg.servicelinecode = 'SL' || e.servicelineid
+                order by pb.providerid
+                 $$;
 
 --- Update Statement
 update_statement := ' update 
@@ -172,8 +124,8 @@ insert_statement := ' insert  (
 merge_statement := ' merge into mid.providerspecialtyfacilityservicelinerating as target using 
                    ('||select_statement||') as source 
                    on source.providerid = target.providerid and source.specialtycode = target.specialtycode and source.servicelinecode = target.servicelinecode 
-                   when matched and source.actioncode = 2 then '||update_statement|| '
-                   when not matched and source.actioncode = 1 then '||insert_statement;
+                   when matched then '||update_statement|| '
+                   when not matched then '||insert_statement;
                    
         
 ---------------------------------------------------------
@@ -204,4 +156,3 @@ status := 'completed successfully';
 
             return status;
 end;
-	

--- a/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/spu_translated_ProviderSpecialtyFacilityServiceLineRating.sql
+++ b/migration_original/ODS1Stage/tables/Mid/ProviderSpecialtyFacilityServiceLineRating/spu_translated_ProviderSpecialtyFacilityServiceLineRating.sql
@@ -77,17 +77,17 @@ select_statement := $$ with CTE_ProviderBatch as (
                     tstslg.servicelinecode, 
                     e.servicelinestar, 
                     e.servicelinedescription, 
-                    b.legacykey, 
+                    sg.legacykey, 
                     tstslg.specialtyid, 
                     tstslg.specialtycode
                 from cte_providerbatch as pb
-                inner join base.providertofacility as pf on pf.providerid = pb.providerid
-                join base.facility as b on pf.facilityid = b.facilityid
-                join base.providertospecialty as ps on pf.providerid = ps.providerid
-                join base.specialtygrouptospecialty as sgs on sgs.specialtyid = ps.specialtyid
-                join base.specialtygroup as sg on sg.specialtygroupid = sgs.specialtygroupid
-                join base.tempspecialtytoservicelineghetto as tstslg on sg.specialtygroupcode = tstslg.specialtycode
-                join cte_union as e on b.legacykey = e.facilityid and tstslg.servicelinecode = 'SL' || e.servicelineid
+                    inner join base.providertofacility as pf on pf.providerid = pb.providerid
+                    join base.facility as b on pf.facilityid = b.facilityid
+                    join base.providertospecialty as ps on pf.providerid = ps.providerid
+                    join base.specialtygrouptospecialty as sgs on sgs.specialtyid = ps.specialtyid
+                    join base.specialtygroup as sg on sg.specialtygroupid = sgs.specialtygroupid
+                    join base.tempspecialtytoservicelineghetto as tstslg on sg.specialtygroupcode = tstslg.specialtycode
+                    join cte_union as e on b.legacykey = e.facilityid and tstslg.servicelinecode = 'SL' || e.servicelineid
                 order by pb.providerid
                  $$;
 


### PR DESCRIPTION
We have much less rows here because the number of facilities has been reduced largely. All the columns have the same nulls and distinct except providerid, we have many less provider ids which makes the table have much less rows.