### PR TITLE
show.solrprovider (xml load 1/3)

### DIFF
--- a/migration_original/ODS1Stage/tables/Show/SOLRProvider/spu_translated_SOLRProvider.sql
+++ b/migration_original/ODS1Stage/tables/Show/SOLRProvider/spu_translated_SOLRProvider.sql
@@ -180,6 +180,15 @@ declare
     if_condition string;
     update_statement_23 string;
     update_statement_24 string;
+    -------------- xml load ----------------
+    select_statement_xml_load_1 string;
+    update_statement_xml_load_1 string;
+    select_statement_facility string;
+    update_statement_facility string;
+    select_statement_condition_hierarchy string;
+    update_statement_condition_hierarchy string;
+    select_statement_cond_mapped string;
+    update_statement_cond_mapped string;
     status string; -- status monitoring
     procedure_name varchar(50) default('sp_load_solrprovider');
     execution_start datetime default getdate();
@@ -2067,6 +2076,1299 @@ update_statement_24 :=  $$
                 		where DisplayStatusCode = 'H' and SubStatusCode = '1'
                         $$;
 
+-----------------------------------------------------------------
+--------------------------- XML LOAD ----------------------------
+-----------------------------------------------------------------
+
+select_statement_xml_load_1 := $$ 
+------------------------AvailabilityXML------------------------
+
+with cte_appointment_availability as (
+    SELECT DISTINCT
+        poaa.ProviderID,
+        aa.AppointmentAvailabilityCode AS aptCd,
+        aa.AppointmentAvailabilityDescription AS aptD
+    FROM
+        Base.ProviderToAppointmentAvailability poaa
+        JOIN Base.AppointmentAvailability aa ON aa.AppointmentAvailabilityID = poaa.AppointmentAvailabilityID
+),
+cte_availability_xml as (
+    SELECT
+        ProviderID,
+        '<aptL>' || listagg( '<apt>' || iff(aptCd is not null,'<aptCd>' || aptCd || '</aptCd>','') ||
+        iff(aptD is not null,'<aptD>' || aptD || '</aptD>','') || '</apt>' , '') || '</aptL>' AS XMLValue
+    FROM
+        cte_appointment_availability
+    GROUP BY
+        ProviderID
+),
+
+-----------------------ProcedureHierarchyXML--------------------
+CTE_ProviderProceduresq AS (
+    SELECT
+        a.ProviderID,
+        a.ProcedureCode,
+        0 AS IsMapped
+    FROM
+        Mid.ProviderProcedure a
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    UNION ALL
+    SELECT
+        a.ProviderID,
+        mt.MedicalTermCode AS ProcedureCode,
+        1 AS IsMapped
+    FROM
+        Base.ProviderToSpecialty a
+        INNER JOIN Base.Specialty b ON b.SpecialtyID = a.SpecialtyID
+        INNER JOIN Base.SpecialtyToProcedureMedical spm ON b.SpecialtyID = spm.SpecialtyID
+        INNER JOIN Base.MedicalTerm mt ON mt.MedicalTermID = spm.ProcedureMedicalID
+        INNER JOIN Base.MedicalTermType mtt ON mt.MedicalTermTypeID = mtt.MedicalTermTypeID
+            AND mtt.MedicalTermTypeCode = 'Procedure'
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    WHERE
+        a.SpecialtyIsRedundant = 0
+        AND a.IsSearchableCalculated = 1
+),
+
+CTE_ProviderProcedureXMLLoads AS (
+    SELECT
+        ProviderID,
+        ProcedureCode,
+        IsMapped
+    FROM
+        CTE_ProviderProceduresq
+),
+cte_procedure_hierarchy as (
+    SELECT DISTINCT
+        pp.ProviderID,
+        dcp.MedicalInt AS prC,
+        dcp.parentHier AS pHier,
+        dcp.childHier AS cHier,
+        dcp.parentSelfHier AS pSelfHier,
+        dcp.parentByTwosHier AS pTwoHier,
+        dcp.parentSelfByTwosHier AS pSelfTwoHier,
+        dcp.ParentNameCodesAlpha AS pNmCdAlpha,
+        dcp.ParentNameCodesInitials AS pNmCdInitial,
+        pp.IsMapped AS isMap
+    FROM
+        CTE_ProviderProcedureXMLLoads pp -- temp schema before
+        JOIN base.DCPHierarchy dcp ON dcp.MedicalInt = pp.ProcedureCode AND dcp.medicaltype = 'Procedure' -- dbo schema before
+),
+
+cte_procedure_hierarchy_xml as (
+    SELECT
+        ProviderID,
+        '<prHierL>' || listagg('<prHier>'|| iff(prC is not null,'<prC>' || prC || '</prC>','') ||
+        iff(pHier is not null,'<pHier>' || pHier || '</pHier>','') ||
+        iff(cHier is not null,'<cHier>' || cHier || '</cHier>','') ||
+        iff(pSelfHier is not null,'<pSelfHier>' || pSelfHier || '</pSelfHier>','') ||
+        iff(pTwoHier is not null,'<pTwoHier>' || pTwoHier || '</pTwoHier>','') ||
+        iff(pSelfTwoHier is not null,'<pSelfTwoHier>' || pSelfTwoHier || '</pSelfTwoHier>','') ||
+        iff(pNmCdAlpha is not null,'<pNmCdAlpha>' || pNmCdAlpha || '</pNmCdAlpha>','') ||
+        iff(pNmCdInitial is not null,'<pNmCdInitial>' || pNmCdInitial || '</pNmCdInitial>','') ||
+        iff(isMap is not null,'<isMap>' || isMap || '</isMap>','') || '</prHier>' , '' ) || '</prHierL>'
+ AS XMLValue
+    FROM
+        cte_procedure_hierarchy
+    GROUP BY
+        ProviderID
+),
+
+
+--------------------------ProcMappedXML--------------------------
+
+cte_proc_mapped as (
+    SELECT DISTINCT
+        sp.ProviderID,
+        mt.MedicalTermCode AS prC,
+        s.SpecialtyCode || '/' || mt.MedicalTermDescription1 || '|' || mt.MedicalTermCode AS prcN
+    FROM
+        Base.SpecialtyToProcedureMedical stpm
+        JOIN Base.MedicalTerm mt ON mt.MedicalTermID = stpm.ProcedureMedicalID
+        JOIN Base.MedicalTermType mtt ON mt.MedicalTermTypeID = mtt.MedicalTermTypeID AND mtt.MedicalTermTypeCode = 'Procedure'
+        JOIN Base.Specialty s ON stpm.SpecialtyID = s.SpecialtyID
+        JOIN Base.ProviderToSpecialty pts ON pts.SpecialtyID = stpm.SpecialtyID
+        JOIN Show.SolrProvider as sp on sp.providerid = pts.providerid
+    WHERE 
+        pts.SpecialtyIsRedundant = 0
+        AND pts.IsSearchableCalculated = 1
+),
+
+cte_proc_mapped_xml as (
+    SELECT
+        ProviderID,
+        '<prL>' || listagg( '<pr>' || iff(prC is not null,'<prC>' || prC || '</prC>','') ||
+        iff(prcN is not null,'<prcN>' || prcN || '</prcN>','') || '</pr>' , '') || '</prL>'  AS XMLValue
+    FROM
+        cte_proc_mapped
+    GROUP BY
+        ProviderID
+),
+
+--------------------------PracSpecHeirXML--------------------------
+
+-- Define the CTE for extracting and transforming specialty data
+cte_specialty_hierarchy as (
+    SELECT
+        p.providerid,
+        spec.SpecialtyCode AS spCd,
+        spec.SpecialtyCode || '/' || TRIM(spec.SpecialtyDescription) || '|' || spec.specialtycode AS prSpHeirBar
+    FROM
+        Base.SpecialtyGroup sgr
+        JOIN Base.SpecialtyGroupToSpecialty sgs ON sgr.SpecialtyGroupID = sgs.SpecialtyGroupID
+        JOIN Base.Specialty spec ON spec.SpecialtyID = sgs.SpecialtyID AND sgr.SpecialtyGroupDescription = spec.SpecialtyDescription
+        JOIN base.providertospecialty as p on p.specialtyid = spec.specialtyid 
+),
+
+cte_prac_spec_hier_xml as (
+    SELECT
+        providerid,
+        '<prSpHeirL>' || listagg('<prSpHeir>' || iff(spCd is not null,'<spCd>' || spCd || '</spCd>','') ||
+iff(prSpHeirBar is not null,'<prSpHeirBar>' || prSpHeirBar || '</prSpHeirBar>','') || '</prSpHeir>', '') || '</prSpHeirL>' as xmlvalue
+    FROM
+        cte_specialty_hierarchy
+    GROUP BY
+        providerid
+),
+
+--------------------------OASXML--------------------------	
+cte_oas_partner AS (
+    SELECT DISTINCT 
+        ProviderId, 
+        P.OASPartnerCode
+    FROM Base.ProviderToClientToOASPartner O 
+        INNER JOIN Base.OASPartner P ON P.OASPartnerId = O.OASPartnerId
+),
+cte_TempPartnerEntity AS (
+    SELECT DISTINCT 
+        pte.primaryentityid as providerid,
+        pte.PartnerCode,
+        pte.PartnerDescription,
+        pte.PartnerTypeCode,
+        pte.PartnerPrimaryEntityID,
+        pte.OfficeCode,
+        pte.PartnerSecondaryEntityID,
+        pte.PartnerTertiaryEntityID,
+        pte.FullURL,
+        pte.PrimaryEntityID,
+        pte.PartnerId,
+        O.OASPartnerCode,
+        pte.ExternalOASPartnerDescription
+    FROM mid.PartnerEntity pte
+    INNER JOIN Show.SolrProvider P ON P.ProviderId = pte.PrimaryEntityID
+    LEFT JOIN cte_oas_partner O ON O.ProviderId = P.ProviderID
+),
+
+Cte_Oas as (
+    SELECT DISTINCT 
+        pte.PrimaryEntityId AS Providerid,
+        pte.OASPartnerCode,
+        pte.PartnerCode AS partCd,
+        pte.PartnerDescription AS partDesc,
+        pte.PartnerTypeCode AS partTyCd,
+        pte.PartnerPrimaryEntityID AS partProvId,
+        pte.OfficeCode AS offCd,
+        pte.PartnerSecondaryEntityID AS partOffId,
+        pte.PartnerTertiaryEntityID AS partPracId,
+        pte.FullURL,
+        pte.ExternalOASPartnerDescription AS ExternalOASPartner
+        -- configL (always empty)
+    FROM
+        cte_TempPartnerEntity pte 
+),
+
+Cte_Oas_xml as (
+    SELECT
+        ProviderID, 
+        replace('<oasL>' || listagg('<oas>' || 
+        iff(OASPartnerCode is not null,'<OASPartnerCode>' || OASPartnerCode || '</OASPartnerCode>','') ||
+        iff(partCd is not null,'<partCd>' || partCd || '</partCd>','') ||
+        iff(partDesc is not null,'<partDesc>' || partDesc || '</partDesc>','') ||
+        iff(partTyCd is not null,'<partTyCd>' || partTyCd || '</partTyCd>','') ||
+        iff(partProvId is not null,'<partProvId>' || partProvId || '</partProvId>','') ||
+        iff(offCd is not null,'<offCd>' || offCd || '</offCd>','') ||
+        iff(partOffId is not null,'<partOffId>' || partOffId || '</partOffId>','') ||
+        iff(partPracId is not null,'<partPracId>' || partPracId || '</partPracId>','') ||
+        iff(FullURL is not null,'<FullURL>' || FullURL || '</FullURL>','') ||
+        iff(ExternalOASPartner is not null,'<ExternalOASPartner>' || ExternalOASPartner || '</ExternalOASPartner>','') || 
+        '</oas>', '') || '</oasL>', '&', '&amp;') AS XMLValue
+    FROM
+        cte_oas
+    GROUP BY
+        ProviderID 
+),
+
+------------------------DEAXML------------------------
+
+cte_dea_identification as (
+    SELECT DISTINCT
+        ppi.ProviderID,
+        ppi.IdentificationValue AS deaN,
+        ppi.EffectiveDate AS deaEfDt,
+        ppi.ExpirationDate AS deaExDt
+    FROM
+        Base.ProviderIdentification ppi
+        JOIN Base.IdentificationType it ON it.IdentificationTypeID = ppi.IdentificationTypeID
+    WHERE 
+        it.IdentificationTypeCode = 'DEA'
+),
+
+cte_dea_xml as (
+    SELECT
+        ProviderID,
+        '<deaL>' || listagg('<dea>' || 
+        iff(deaN is not null,'<deaN>' || deaN || '</deaN>','') ||
+        iff(deaEfDt is not null,'<deaEfDt>' || deaEfDt || '</deaEfDt>','') ||
+        iff(deaExDt is not null,'<deaExDt>' || deaExDt || '</deaExDt>','') || 
+        '</dea>', '') || '</deaL>'
+ AS XMLValue
+    FROM
+        cte_dea_identification
+    GROUP BY
+        ProviderID
+),
+
+------------------------EmailAddressXML------------------------
+
+cte_provider_email as (
+    SELECT DISTINCT
+        ProviderID,
+        EmailAddress AS eAdd,
+        EmailRank AS eRank
+    FROM
+        Base.ProviderEmail 
+),
+
+cte_email_address_xml as (
+    SELECT
+        ProviderID,
+        '<eaL>' || listagg('<ea>' || 
+        iff(eAdd is not null,'<eAdd>' || eAdd || '</eAdd>','') ||
+        iff(eRank is not null,'<eRank>' || eRank || '</eRank>','') || 
+        '</ea>', '') || '</eaL>' 
+ AS XMLValue
+    FROM
+        cte_provider_email
+    GROUP BY
+        ProviderID
+),
+
+------------------------DegreeXML------------------------
+
+cte_degree as (
+    SELECT DISTINCT
+        ptd.ProviderID,
+        d.DegreeAbbreviation AS degA,
+        d.DegreeDescription AS degD,
+        ptd.DegreePriority AS rank,
+        TO_DATE(ptd.LastUpdateDate) AS updDte
+    FROM
+        Base.Degree d
+        JOIN Base.ProviderToDegree ptd ON d.DegreeID = ptd.DegreeID
+),
+
+cte_degree_xml as (
+    SELECT
+        ProviderID,
+        '<degL>' || listagg('<deg>' || 
+        iff(degA is not null,'<degA>' || degA || '</degA>','') ||
+        iff(degD is not null,'<degD>' || degD || '</degD>','') ||
+        iff(rank is not null,'<rank>' || rank || '</rank>','') ||
+        iff(TO_CHAR(updDte, 'YYYY-MM-DD') is not null,'<updDte>' || TO_CHAR(updDte, 'YYYY-MM-DD') || '</updDte>','') || 
+        '</deg>', '') || '</degL>'
+ AS XMLValue
+    FROM
+        cte_degree
+    GROUP BY
+        ProviderID
+),
+
+------------------------SurveyXML------------------------
+
+cte_survey as (
+    SELECT DISTINCT
+        dP.ProviderID,
+        sqa.SurveyQuestion AS qstn,
+        sqa.SurveyQuestionGroupDescription AS qGrp,
+        psqrm.SurveyAnswer AS ansId,
+        ps.QuestionID AS qId,
+        ps.QuestionSort AS qSrt,
+        0 AS qDSrt, -- Originally ps.QuestionDisplaySort
+        ps.ProviderAverageScore AS pScr,
+        ps.QuestionCount AS qCnt,
+        ps.NationalAverageScore AS nScr,
+        (ps.ProviderAverageScore / 5) * 100 AS pScrPct,
+        ROUND((((ps.ProviderAverageScore / 5) * 100) / 5), 0) * 5 AS pScrPctRnd,
+        (ps.NationalAverageScore / 5) * 100 AS nScrPct,
+        ROUND((((ps.NationalAverageScore / 5) * 100) / 5), 0) * 5 AS nScrPctRnd,
+        ps.PositiveResponse AS nPosScr,
+        ps.NegativeResponse AS nNegScr,
+        psqrm.SurveyAnswerText AS range,
+        nsqrm.SurveyAnswerText || ' National Average' AS nRange,
+        IFF(psqrm.SurveyScore < nsqrm.SurveyScore AND psqrm.SurveyQuestionCode = '226', 'longer than national average',
+            IFF(psqrm.SurveyScore > nsqrm.SurveyScore AND psqrm.SurveyQuestionCode = '226', 'shorter than national average',
+                IFF(psqrm.SurveyScore = nsqrm.SurveyScore AND psqrm.SurveyQuestionCode = '226', 'same as national average',
+                    IFF(psqrm.SurveyScore < nsqrm.SurveyScore, 'below national average',
+                        IFF(psqrm.SurveyScore > nsqrm.SurveyScore, 'above national average',
+                            IFF(psqrm.SurveyScore = nsqrm.SurveyScore, 'same as national average',
+                                IFF(ps.ProviderAverageScore < ps.NationalAverageScore, 'below national average',
+                                    IFF(ps.ProviderAverageScore > ps.NationalAverageScore, 'above national average',
+                                        IFF(ps.ProviderAverageScore = ps.NationalAverageScore, 'same as national average', '')
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        ) AS nScrCompr
+    FROM
+        Base.ProviderSurveyAggregate ps
+        INNER JOIN base.Provider dP ON dP.ProviderCode = ps.ProviderCode
+        INNER JOIN Show.SOLRProviderSurveyQuestionAndAnswer sqa ON ps.QuestionID = sqa.SurveyQuestionCode AND sqa.SurveyTempletVersion IS NULL
+        LEFT JOIN Mid.SurveyQuestionRangeMapping psqrm ON ps.QuestionID = psqrm.SurveyQuestionCode AND ROUND(ps.ProviderAverageScore,0) = psqrm.SurveyScore
+        LEFT JOIN Mid.SurveyQuestionRangeMapping nsqrm ON ps.QuestionID = nsqrm.SurveyQuestionCode AND ROUND(ps.NationalAverageScore,0) = nsqrm.SurveyScore
+),
+
+cte_survey_xml as (
+    SELECT
+        ProviderID,
+        '<svyL>' || listagg('<svy>' || 
+        iff(qstn is not null,'<qstn>' || qstn || '</qstn>','') ||
+        iff(qGrp is not null,'<qGrp>' || qGrp || '</qGrp>','') ||
+        iff(ansId is not null,'<ansId>' || ansId || '</ansId>','') ||
+        iff(qId is not null,'<qId>' || qId || '</qId>','') ||
+        iff(qSrt is not null,'<qSrt>' || qSrt || '</qSrt>','') ||
+        iff(pScr is not null,'<pScr>' || pScr || '</pScr>','') ||
+        iff(qCnt is not null,'<qCnt>' || qCnt || '</qCnt>','') ||
+        iff(nScr is not null,'<nScr>' || nScr || '</nScr>','') ||
+        iff(pScrPct is not null,'<pScrPct>' || pScrPct || '</pScrPct>','') ||
+        iff(pScrPctRnd is not null,'<pScrPctRnd>' || pScrPctRnd || '</pScrPctRnd>','') ||
+        iff(nScrPct is not null,'<nScrPct>' || nScrPct || '</nScrPct>','') ||
+        iff(nScrPctRnd is not null,'<nScrPctRnd>' || nScrPctRnd || '</nScrPctRnd>','') ||
+        iff(nPosScr is not null,'<nPosScr>' || nPosScr || '</nPosScr>','') ||
+        iff(nNegScr is not null,'<nNegScr>' || nNegScr || '</nNegScr>','') ||
+        iff(range is not null,'<range>' || range || '</range>','') ||
+        iff(nRange is not null,'<nRange>' || nRange || '</nRange>','') ||
+        iff(nScrCompr is not null,'<nScrCompr>' || nScrCompr || '</nScrCompr>','') || 
+        '</svy>', '') || '</svyL>'
+ AS XMLValue
+    FROM
+        cte_survey
+    GROUP BY
+        ProviderID
+) ,
+
+------------------------ClinicalFocusDCPXML------------------------
+
+cte_mtcode as (
+    SELECT
+        ProviderId,
+        refMedicalTermCode AS MTCode,
+        NationalRankingB AS NRankB,
+        ClinicalFocusShortDescription
+    FROM
+        Base.ClinicalFocusDCP 
+),
+
+cte_mtcode_xml as (
+    SELECT
+        ProviderId,
+       '<MTCodeL>' || listagg('<MTCode>' || 
+        iff(MTCode is not null,'<MTCode>' || MTCode || '</MTCode>','') ||
+        iff(NRankB is not null,'<NRankB>' || NRankB || '</NRankB>','') || 
+        '</MTCode>', '') || '</MTCodeL>'
+ AS XMLValue
+    FROM
+        cte_mtcode
+    GROUP BY
+        ProviderId
+),
+
+cte_clinical_focus_dcp as (
+    SELECT
+        C.providerid,
+        C.ClinicalFocusShortDescription AS CLFdesc,
+        cte.xmlvalue
+    FROM
+        Base.ClinicalFocusDCP C
+        JOIN cte_mtcode_xml cte ON cte.providerid = C.providerid
+),
+
+cte_clinical_focus_dcp_xml as (
+    SELECT
+        providerid,
+        '<CLFdescL>' || listagg('<CLFdesc>' || 
+        iff(CLFdesc is not null,'<CLFdesc>' || CLFdesc || '</CLFdesc>','') || 
+        '</CLFdesc>', '') || '</CLFdescL>'
+ AS XMLValue
+    FROM
+        cte_clinical_focus_dcp
+    GROUP BY
+        providerid
+) ,
+
+------------------------CLinicalFocusXML------------------------
+
+cte_from_clinical_focus as (
+SELECT DISTINCT 
+    C.ProviderID, 
+    dCF.ClinicalFocusId, 
+    dCF.ClinicalFocusDescription
+FROM Base.ProviderToClinicalFocus C
+    INNER JOIN	Base.ClinicalFocus dCF ON dCF.ClinicalFocusID = C.ClinicalFocusID
+),
+
+cte_specialty_codes as (
+    SELECT
+        cfs.ClinicalFocusID,
+        '|' || s.SpecialtyCode AS SpecialtyCode
+    FROM
+        Base.ClinicalFocusToSpecialty cfs
+        INNER JOIN Base.Specialty s ON s.SpecialtyID = cfs.SpecialtyID
+),
+
+cte_concatenated_specialty_codes as (
+    SELECT
+        ClinicalFocusID,
+        LISTAGG(SpecialtyCode, '') WITHIN GROUP (ORDER BY SpecialtyCode) AS CLFSpecId
+    FROM
+        cte_specialty_codes
+    GROUP BY
+        ClinicalFocusID
+),
+
+cte_specialty_codes_xml as (
+    SELECT
+        ClinicalFocusID,
+        listagg(iff(CLFSpecId is not null,'<CLFSpecId>' || CLFSpecId || '</CLFSpecId>',''), '' )
+ AS XMLValue
+    FROM
+        cte_concatenated_specialty_codes
+    GROUP BY
+        ClinicalFocusId
+),
+
+cte_mtcode2 as (
+    SELECT
+        ProviderId,
+        ProviderDCPCount AS PDCP,
+        CAST(AverageBPercentile AS INT) AS AvgP,
+        ProviderDCPFillPercent AS CFProvFill,
+        IsProviderDCPCountOverLowThreshold AS DCPThresh,
+        ClinicalFocusScore AS CFScore,
+        ProviderClinicalFocusRank AS CFRank
+    FROM
+        Base.ProviderToClinicalFocus 
+),
+
+cte_mtcode_xml as (
+    SELECT
+        ProviderId,
+        '<MTCodeL>' || listagg('<MTCode>' || 
+        iff(PDCP is not null,'<pdcp>' || PDCP || '</pdcp>','') ||
+        iff(avgp is not null,'<avgp>' || avgp || '</avgp>','') ||
+        iff(CFProvFill is not null,'<cfprovfill>' || CFProvFill || '</cfprovfill>','') ||
+        iff(DCPThresh is not null,'<dcpthresh>' || DCPThresh || '</dcpthresh>','') ||
+        iff(CFScore is not null,'<cfscore>' || CFScore || '</cfscore>','') ||
+        iff(CFRank is not null,'<cfrank>' || CFRank || '</cfrank>','') || 
+        '</MTCode>', '') || '</MTCodeL>'
+ AS XMLValue
+    FROM
+        cte_mtcode2
+    GROUP BY
+        ProviderId
+),
+
+cte_clinical_focus as (
+SELECT		
+    C.ProviderId,
+    C.ClinicalFocusId AS CLFId,
+	C.ClinicalFocusDescription AS CLFDesc,
+    code.xmlvalue as clfspecid,
+    mt.xmlvalue as mtcode
+FROM Cte_from_clinical_focus as c
+    JOIN cte_specialty_codes_xml as code on code.clinicalfocusid = c.clinicalfocusid
+    JOIN cte_mtcode_xml as mt on mt.providerid = c.providerid
+),
+
+cte_clinical_focus_xml as (
+SELECT
+        providerid,
+        '<CLFIdL>' || listagg('<CLF>' || 
+        iff(clfId is not null,'<clfId>' || clfId || '</clfId>','') ||
+        iff(clfDesc is not null,'<clfDesc>' || clfDesc || '</clfDesc>','') ||
+        iff(clfspecid is not null,'<clfspecid>' || clfspecid || '</clfspecid>','') || 
+        '</CLF>', '') || '</CLFIdL>'
+ AS XMLValue
+    FROM
+        cte_clinical_focus
+    GROUP BY
+        providerid
+) ,
+
+------------------------TrainingXML------------------------
+
+cte_training as (
+    SELECT
+        trn.ProviderID,
+        t.TrainingCode AS trCd,
+        t.TrainingDescription AS trD,
+        trn.TrainingLink AS trUrl
+    FROM
+        Base.ProviderTraining trn
+        INNER JOIN Base.Training t ON trn.TrainingID = t.TrainingID
+    WHERE
+        t.IsActive = 1
+),
+
+cte_training_xml as (
+    SELECT
+        ProviderID,
+        '<trL>' || listagg('<tr>' || 
+        iff(trCd is not null,'<trCd>' || trCd || '</trCd>','') ||
+        iff(trD is not null,'<trD>' || trD || '</trD>','') ||
+        iff(trUrl is not null,'<trUrl>' || trUrl || '</trUrl>','') || 
+        '</tr>', '') || '</trL>' 
+ AS XMLValue
+    FROM
+        cte_training
+    GROUP BY
+        ProviderID
+),
+
+------------------------LastUpdateDateXML------------------------
+cte_last_update_date_xml as (
+SELECT
+    p.ProviderId,
+    lu.LastUpdateDatePayload as XMLValue
+FROM Show.SolrProvider as p
+    JOIN Base.ProviderLastUpdateDate as lu on p.providerid = lu.providerid
+),
+
+------------------------SmartReferralXML------------------------
+
+CTE_ClientImages AS (
+SELECT DISTINCT 
+    fd.ClientToProductID, 
+    fd.ImageFilePath as Logo
+FROM Base.vwuPDCClientDetail fd 
+WHERE fd.ImageFilePath IS NOT NULL
+),
+
+CTE_Smart_Referral AS (
+SELECT 	   
+    p.ProviderID, 
+    c.ClientCode as srCli, 
+    ci.Logo as srLogo
+FROM Show.SolrProvider as p   
+    INNER JOIN Base.Provider p2 ON p2.ProviderID = p.ProviderID
+    INNER JOIN Base.Client c ON c.ClientID = p2.SmartReferralClientID -- this is empty now in base.provider as it does not come in the new json, so this join will return empty for now
+    INNER JOIN Base.ClientToProduct cp  ON cp.ClientID = c.ClientID
+    LEFT JOIN  CTE_ClientImages ci ON ci.ClientToProductID = cp.ClientToProductID
+QUALIFY ROW_NUMBER() OVER (PARTITION BY p.ProviderID ORDER BY CASE WHEN ci.logo IS NOT NULL THEN 0 ELSE 1 END) = 1
+),
+
+cte_smart_referral_xml as (
+    SELECT
+        ProviderID,
+        '<srL>' || listagg('<sr>' || 
+        iff(srCli is not null,'<srCli>' || srCli || '</srCli>','') ||
+        iff(srLogo is not null,'<srLogo>' || srLogo || '</srLogo>','') || 
+        '</sr>', '') || '</srL>'
+ AS XMLValue
+    FROM
+        cte_smart_referral
+    GROUP BY
+        ProviderID
+)
+
+
+SELECT
+    p.providerid,
+    to_variant(parse_xml( avail.xmlvalue)) as availabilityxml,
+    to_variant(parse_xml (proch.xmlvalue)) as procedurehierarchyxml,
+    to_variant( parse_xml(procm.xmlvalue)) as procmappedxml,
+    to_variant( parse_xml(pspec.xmlvalue)) as pracspecheirxml,
+    to_variant( parse_xml(oas.xmlvalue)) as oasxml,
+    to_variant( parse_xml(dea.xmlvalue)) as deaxml,
+    to_variant( parse_xml(emad.xmlvalue)) as emailaddressxml,
+    to_variant( parse_xml(degree.xmlvalue)) as degreexml,
+    to_variant( parse_xml(survey.xmlvalue)) as surveyxml,
+    to_variant( parse_xml(cfdcp.xmlvalue)) as clinicalfocusdcpxml, 
+    to_variant( parse_xml(cfoc.xmlvalue)) as clinicalfocusxml,
+    to_variant( parse_xml(train.xmlvalue)) as trainingxml,
+    to_variant( parse_xml(ldate.xmlvalue)) as lastupdatedatexml,
+    smref.srcli as smartreferralclientcode,
+    to_variant( parse_xml(smart.xmlvalue)) as smartreferralxml,
+    CASE WHEN survey.xmlvalue IS NULL THEN 0 ELSE 1 END AS HasSurveyXML,
+    CASE WHEN dea.xmlvalue IS NULL THEN 0 ELSE 1 END AS HasDEAXML,
+    CASE WHEN emad.xmlvalue IS NULL THEN 0 ELSE 1 END AS HasEmailAddressXML
+FROM Show.SolrProvider as P
+    LEFT JOIN cte_availability_xml AS avail ON avail.providerid = p.providerid
+    LEFT JOIN cte_procedure_hierarchy_xml  AS proch ON proch.providerid = p.providerid
+    LEFT JOIN cte_proc_mapped_xml AS procm ON procm.providerid = p.providerid
+    LEFT JOIN cte_prac_spec_hier_xml AS pspec ON pspec.providerid = p.providerid
+    LEFT JOIN cte_oas_xml  AS oas ON oas.providerid = p.providerid -- really fast
+    LEFT JOIN cte_dea_xml AS dea ON dea.providerid = p.providerid -- fast
+    LEFT JOIN cte_email_address_xml AS emad ON emad.providerid = p.providerid --fast
+    LEFT JOIN cte_degree_xml  AS degree ON degree.providerid = p.providerid --fast
+    LEFT JOIN cte_survey_xml  AS survey ON survey.providerid = p.providerid
+    LEFT JOIN cte_clinical_focus_dcp_xml AS cfdcp ON cfdcp.providerid = p.providerid
+    LEFT JOIN cte_clinical_focus_xml  AS cfoc ON cfoc.providerid = p.providerid
+    LEFT JOIN cte_training_xml  AS train ON train.providerid = p.providerid --fast
+    LEFT JOIN cte_last_update_date_xml AS ldate ON ldate.providerid = p.providerid
+    LEFT JOIN CTE_Smart_Referral  AS smref ON smref.providerid = p.providerid
+    LEFT JOIN cte_smart_referral_xml  AS smart ON smart.providerid = p.providerid $$;
+
+
+update_statement_xml_load_1 := $$ update show.solrprovider as target
+                                    set target.availabilityxml = source.availabilityxml,
+                                        target.procedurehierarchyxml = source.procedurehierarchyxml,
+                                        target.procmappedxml = source.procmappedxml,
+                                        target.pracspecheirxml = source.pracspecheirxml,
+                                        target.oasxml = source.oasxml,
+                                        target.deaxml = source.deaxml,
+                                        target.emailaddressxml = source.emailaddressxml,
+                                        target.degreexml = source.degreexml,
+                                        target.surveyxml = source.surveyxml,
+                                        target.clinicalfocusdcpxml = source.clinicalfocusdcpxml,
+                                        target.clinicalfocusxml = source.clinicalfocusxml,
+                                        target.trainingxml = source.trainingxml,
+                                        target.lastupdatedatexml = source.lastupdatedatexml,
+                                        target.smartreferralclientcode = source.smartreferralclientcode,
+                                        target.smartreferralxml = source.smartreferralxml,
+                                        target.HasSurveyXML = source.HasSurveyXML,
+                                        target.HasDEAXML = source.HasDEAXML,
+                                        target.HasEmailAddressXML = source.HasEmailAddressXML
+                                    from ($$ || select_statement_xml_load_1 || $$) as source
+                                        where target.providerid = source.providerid $$;
+                                        
+--------------------------ConditionHierarchyXML--------------------------
+-- this takes long 
+select_statement_condition_hierarchy := $$ with CTE_ProviderConditionsq AS (
+    SELECT 
+        a.ProviderID,
+        a.ConditionCode,
+        0 AS IsMapped
+    FROM
+        Mid.ProviderCondition a
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    UNION ALL
+    SELECT 
+        a.ProviderID,
+        mt.MedicalTermCode AS ConditionCode,
+        1 AS IsMapped
+    FROM
+        Base.ProviderToSpecialty a
+        INNER JOIN Base.Specialty b ON b.SpecialtyID = a.SpecialtyID
+        INNER JOIN Base.SpecialtyToCondition spm ON b.SpecialtyID = spm.SpecialtyID
+        INNER JOIN Base.MedicalTerm mt ON mt.MedicalTermID = spm.ConditionID
+        INNER JOIN Base.MedicalTermType mtt ON mt.MedicalTermTypeID = mtt.MedicalTermTypeID
+            AND mtt.MedicalTermTypeCode = 'Condition'
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    WHERE
+        a.SpecialtyIsRedundant = 0
+        AND a.IsSearchableCalculated = 1
+),
+
+CTE_ProviderConditionXMLLoads AS (
+    SELECT distinct
+        ProviderID,
+        ConditionCode,
+        IsMapped
+    FROM
+        CTE_ProviderConditionsq
+),
+cte_condition_hierarchy as (
+    SELECT
+        DISTINCT 
+        pp.ProviderID,
+        dcp.MedicalInt AS condC,
+        dcp.parentHier AS pHier,
+        dcp.childHier AS cHier,
+        dcp.parentSelfHier AS pSelfHier,
+        dcp.parentByTwosHier AS pTwoHier,
+        dcp.parentSelfByTwosHier AS pSelfTwoHier,
+        dcp.ParentNameCodesAlpha AS pNmCdAlpha,
+        dcp.ParentNameCodesInitials AS pNmCdInitial,
+        pp.IsMapped AS isMap
+    FROM
+        CTE_ProviderConditionXMLLoads pp -- temp schema before
+        INNER JOIN base.DCPHierarchy dcp ON dcp.MedicalInt = pp.ConditionCode AND dcp.medicaltype = 'Condition' -- dbo schema before
+),
+
+cte_condition_hierarchy_xml as (
+    SELECT
+        ProviderID,
+        '<condHierL>' || listagg( '<condHier>' || iff(condC is not null,'<condC>' || condC || '</condC>','') ||
+        iff(pHier is not null,'<pHier>' || pHier || '</pHier>','') ||
+        iff(cHier is not null,'<cHier>' || cHier || '</cHier>','') ||
+        iff(pSelfHier is not null,'<pSelfHier>' || pSelfHier || '</pSelfHier>','') ||
+        iff(pTwoHier is not null,'<pTwoHier>' || pTwoHier || '</pTwoHier>','') ||
+        iff(pSelfTwoHier is not null,'<pSelfTwoHier>' || pSelfTwoHier || '</pSelfTwoHier>','') ||
+        iff(pNmCdAlpha is not null,'<pNmCdAlpha>' || pNmCdAlpha || '</pNmCdAlpha>','') ||
+        iff(pNmCdInitial is not null,'<pNmCdInitial>' || pNmCdInitial || '</pNmCdInitial>','') ||
+        iff(isMap is not null,'<isMap>' || isMap || '</isMap>','') || '</condHier>' , '') || '</condHierL>'
+ AS XMLValue
+    FROM
+        cte_condition_hierarchy
+    GROUP BY
+        ProviderID
+) 
+SELECT
+    ProviderID,
+    to_variant(parse_xml(XMLValue)) as ConditionHierarchyXML
+FROM
+    cte_condition_hierarchy_xml $$;
+
+update_statement_condition_hierarchy := $$ update show.solrprovider as target
+                                            set target.ConditionHierarchyXML = source.ConditionHierarchyXML
+                                            from ( $$ || select_statement_condition_hierarchy || $$ ) as source
+                                            where target.ProviderID = source.ProviderID $$;
+
+--------------------------CondMappedXML--------------------------
+select_statement_cond_mapped := $$ with cte_cond_mapped as (
+    SELECT DISTINCT
+        sp.ProviderId,
+        mt.MedicalTermCode AS cndC,
+        s.SpecialtyCode || '/' || mt.MedicalTermDescription1 || '|' || mt.MedicalTermCode AS cndN,
+    FROM
+        Base.SpecialtyToCondition stc
+        JOIN Base.MedicalTerm mt ON mt.MedicalTermID = stc.ConditionID
+        JOIN Base.MedicalTermType mtt ON mt.MedicalTermTypeID = mtt.MedicalTermTypeID AND mtt.MedicalTermTypeCode = 'Condition'
+        JOIN Base.Specialty s ON stc.SpecialtyID = s.SpecialtyID
+        JOIN Base.ProviderToSpecialty pts ON pts.SpecialtyID = stc.SpecialtyID AND pts.SpecialtyIsRedundant = 0 AND pts.IsSearchableCalculated = 1
+        JOIN Show.SolrProvider as sp on sp.providerid = pts.providerid
+),
+
+cte_cond_mapped_xml as (
+    SELECT
+        ProviderId,
+        '<cndL>' || listagg('<cnd>' || iff(cndC is not null,'<cndC>' || cndC || '</cndC>','') ||
+        iff(cndN is not null,'<cndN>' || cndN || '</cndN>','') || '</cnd>', '') || '</cndL>'
+ AS XMLValue
+    FROM
+        cte_cond_mapped
+    GROUP BY
+        ProviderId
+) 
+select 
+    providerid,
+    to_variant(parse_xml(xmlvalue)) as condmappedxml
+from cte_cond_mapped_xml $$;
+
+update_statement_cond_mapped := $$ update show.solrprovider as target
+                                    set target.CondMappedXML = source.condmappedxml
+                                    from ( $$ || select_statement_cond_mapped ||  $$ ) as source
+                                    where target.ProviderID = source.ProviderID $$;
+
+------------------------FacilityXML------------------------
+select_statement_facility := $$ with CTE_ProviderProceduresq AS (
+    SELECT
+        a.ProviderID,
+        a.ProcedureCode,
+        0 AS IsMapped
+    FROM
+        Mid.ProviderProcedure a
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    UNION ALL
+    SELECT
+        a.ProviderID,
+        mt.MedicalTermCode AS ProcedureCode,
+        1 AS IsMapped
+    FROM
+        Base.ProviderToSpecialty a
+        INNER JOIN Base.Specialty b ON b.SpecialtyID = a.SpecialtyID
+        INNER JOIN Base.SpecialtyToProcedureMedical spm ON b.SpecialtyID = spm.SpecialtyID
+        INNER JOIN Base.MedicalTerm mt ON mt.MedicalTermID = spm.ProcedureMedicalID
+        INNER JOIN Base.MedicalTermType mtt ON mt.MedicalTermTypeID = mtt.MedicalTermTypeID
+            AND mtt.MedicalTermTypeCode = 'Procedure'
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    WHERE
+        a.SpecialtyIsRedundant = 0
+        AND a.IsSearchableCalculated = 1
+),
+
+CTE_ProviderProcedureXMLLoads AS (
+    SELECT
+        ProviderID,
+        ProcedureCode,
+        IsMapped
+    FROM
+        CTE_ProviderProceduresq
+),
+
+CTE_ProviderConditionsq AS (
+    SELECT 
+        a.ProviderID,
+        a.ConditionCode,
+        0 AS IsMapped
+    FROM
+        Mid.ProviderCondition a
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    UNION ALL
+    SELECT 
+        a.ProviderID,
+        mt.MedicalTermCode AS ConditionCode,
+        1 AS IsMapped
+    FROM
+        Base.ProviderToSpecialty a
+        INNER JOIN Base.Specialty b ON b.SpecialtyID = a.SpecialtyID
+        INNER JOIN Base.SpecialtyToCondition spm ON b.SpecialtyID = spm.SpecialtyID
+        INNER JOIN Base.MedicalTerm mt ON mt.MedicalTermID = spm.ConditionID
+        INNER JOIN Base.MedicalTermType mtt ON mt.MedicalTermTypeID = mtt.MedicalTermTypeID
+            AND mtt.MedicalTermTypeCode = 'Condition'
+        INNER JOIN Show.SolrProvider pr ON a.ProviderID = pr.ProviderId
+    WHERE
+        a.SpecialtyIsRedundant = 0
+        AND a.IsSearchableCalculated = 1
+),
+
+CTE_ProviderConditionXMLLoads AS (
+    SELECT distinct
+        ProviderID,
+        ConditionCode,
+        IsMapped
+    FROM
+        CTE_ProviderConditionsq
+),
+cte_related_spec AS (
+    SELECT
+        DISTINCT 
+        ats.awardcode AS awardid,
+        s.SpecialtyCode || '|' AS SpecialtyCode
+    FROM
+        Base.AwardToSpecialty ats
+        JOIN Base.Specialty s ON ats.SpecialtyCode = s.SpecialtyCode
+        JOIN Base.ProviderToSpecialty pts ON pts.SpecialtyID = s.SpecialtyID
+    WHERE
+        pts.SpecialtyIsRedundant = 0
+        AND pts.IsSearchableCalculated = 1
+),
+
+cte_related_spec_xml AS (
+    SELECT
+        awardid,
+        listagg(iff(SpecialtyCode is not null, SpecialtyCode ,'')) AS XMLValue
+    FROM
+        cte_related_spec
+    GROUP BY
+        awardId
+),
+cte_related_parent_spec AS (
+    SELECT distinct
+        ats.AwardCode AS Awardid,
+        s.SpecialtyCode || ':' || psp.PracticingSpecialtyCode || '|' AS SpecialtyCode
+    FROM
+        Base.AwardToSpecialty ats
+        JOIN Base.Specialty s ON ats.SpecialtyCode = s.SpecialtyCode
+        JOIN Base.ProviderToSpecialty pts ON pts.SpecialtyID = s.SpecialtyID
+        JOIN Base.SpecialtyGroupToSpecialty sgtos ON s.SpecialtyID = sgtos.SpecialtyID
+        JOIN Base.SpecialtyGroup sg ON sg.SpecialtyGroupID = sgtos.SpecialtyGroupID
+        JOIN Show.vwuPracticingSpecialtyToGroupSpecialtyPrimary psp ON sg.SpecialtyGroupCode = psp.RolledUpSpecialtyCode
+    WHERE
+        pts.SpecialtyIsRedundant = 0
+        AND s.IsPediatricAdolescent = 0
+        AND pts.IsSearchableCalculated = 1
+        AND psp.PracticingSpecialtyCode <> s.SpecialtyCode
+),
+
+cte_related_parent_spec_xml AS (
+    SELECT
+        awardid,
+        listagg(iff(SpecialtyCode is not null, SpecialtyCode ,'')) AS XMLValue
+    FROM
+        cte_related_parent_spec
+    GROUP BY
+        awardid
+),
+
+cte_related_child_spec AS (
+    SELECT distinct
+        ats.awardcode AS awardid,
+        j.SpecialtyCode || ':' || s.SpecialtyCode || '|' AS SpecialtyCode
+    FROM
+        Base.AwardToSpecialty ats
+        JOIN Base.Specialty j ON ats.SpecialtyCode = j.SpecialtyCode
+        JOIN Base.ProviderToSpecialty pts ON pts.SpecialtyID = j.SpecialtyID
+        JOIN Show.vwuPracticingSpecialtyToGroupSpecialtyPrimary psp ON j.SpecialtyCode = psp.PracticingSpecialtyCode
+        JOIN Base.SpecialtyGroup sg ON psp.RolledUpSpecialtyCode = sg.SpecialtyGroupCode
+        JOIN Base.SpecialtyGroupToSpecialty sgtos ON sg.SpecialtyGroupID = sgtos.SpecialtyGroupID
+        JOIN Base.Specialty s ON s.SpecialtyID = sgtos.SpecialtyID
+    WHERE
+        pts.SpecialtyIsRedundant = 0
+        AND s.IsPediatricAdolescent = 0
+        AND j.IsPediatricAdolescent = 0
+        AND pts.IsSearchableCalculated = 1
+        AND j.SpecialtyCode <> s.SpecialtyCode
+),
+
+cte_related_child_spec_xml AS ( 
+    SELECT
+        awardid,
+        listagg(iff(SpecialtyCode is not null, SpecialtyCode ,'')) AS XMLValue
+    FROM
+        cte_related_child_spec
+    GROUP BY
+        awardid
+) ,
+
+cte_related_proc AS (
+    SELECT DISTINCT
+        atp.awardcode AS awardid,
+        pp.ProcedureCode || '|' AS ProcedureCode
+    FROM
+        Base.AwardToProcedure atp
+        JOIN Base.MedicalTerm mt ON atp.ProcedureMedicalID = mt.MedicalTermID
+        JOIN CTE_ProviderProcedureXMLLoads pp ON mt.MedicalTermCode = pp.ProcedureCode
+),
+
+cte_related_proc_xml AS (
+    SELECT
+        awardid,
+        listagg(iff(ProcedureCode is not null, ProcedureCode ,'')) AS XMLValue
+    FROM
+        cte_related_proc
+    GROUP BY
+        awardid
+),
+
+cte_related_cond AS (
+    SELECT DISTINCT
+        atc.awardcode AS awardid,
+        pc.ConditionCode || '|' as conditioncode
+    FROM
+        Base.AwardToCondition atc
+        JOIN Base.MedicalTerm mt ON atc.ConditionID = mt.MedicalTermID
+        JOIN CTE_ProviderConditionXMLLoads pc ON mt.MedicalTermCode = pc.ConditionCode
+),
+
+cte_related_cond_xml AS (
+    SELECT
+        awardid,
+        listagg(iff(ConditionCode is not null, ConditionCode ,'')) AS XMLValue
+    FROM
+        cte_related_cond
+    GROUP BY
+        awardid
+),
+
+cte_award AS (
+SELECT distinct
+    x.facilityid,
+    y.AwardCode AS awCd, 
+    w.AwardCategoryCode AS awTypCd,
+    y.AwardDisplayName AS awNm, 
+    x.DisplayDataYear AS dispAwYr,
+    x.IsBestInd AS isBest,
+    x.IsMaxYear AS isMaxYr,
+    rspec.xmlvalue as relatedspec,
+    rpar.xmlvalue as relatedparentspec,
+    rchild.xmlvalue as relatedchildspec,
+    rproc.xmlvalue as relatedproc,
+    rcond.xmlvalue as relatedcond
+FROM ERMART1.Facility_FacilityToAward x
+    JOIN Base.Award y ON  x.AwardName = y.AwardName
+    JOIN Base.AwardCategory w ON w.AwardCategoryID = y.AwardCategoryID
+    LEFT JOIN ERMART1.Facility_ServiceLine z ON x.SpecialtyCode = z.ServiceLineID
+    JOIN Cte_Related_spec_xml as rspec on rspec.awardid = x.awardid 
+    JOIN Cte_Related_parent_Spec_xml as rpar on rpar.awardid = x.awardid
+    JOIN cte_related_child_spec_xml as rchild on rchild.awardid = x.awardid
+    JOIN Cte_related_proc_xml as rproc on rproc.awardid = x.awardid
+    JOIN Cte_related_cond_xml as rcond on rcond.awardid = x.awardid
+WHERE	
+    x.IsMaxYear = 1
+),
+
+cte_award_xml AS (
+ SELECT
+        facilityid,
+        '<awardL>' || listagg('<award>' || 
+        iff(awCd is not null,'<awcd>' || awCd || '</awcd>','') ||
+        iff(awTypCd is not null,'<awtypcd>' || awTypCd || '</awtypcd>','') ||
+        iff(awNm is not null,'<awnm>' || awNm || '</awnm>','') ||
+        iff(dispAwYr is not null,'<dispawyr>' || dispAwYr || '</dispawyr>','') ||
+        iff(isBest is not null,'<isbest>' || isBest || '</isbest>','') ||
+        iff(isMaxYr is not null,'<ismaxyr>' || isMaxYr || '</ismaxyr>','') ||
+        iff(relatedspec is not null,'<relatedspec>' || relatedspec || '</relatedspec>','') ||
+        iff(relatedparentspec is not null,'<relatedparentspec>' || relatedparentspec || '</relatedparentspec>','') ||
+        iff(relatedchildspec is not null,'<relatedchildspec>' || relatedchildspec || '</relatedchildspec>','') ||
+        iff(relatedproc is not null,'<relatedproc>' || relatedproc || '</relatedproc>','') ||
+        iff(relatedcond is not null,'<relatedcond>' || relatedcond || '</relatedcond>','') || 
+        '</award>', '') || '</awardL>'
+ AS XMLValue
+    FROM
+        cte_award
+    GROUP BY
+        facilityid
+),
+
+cte_related_spec2 as (
+    SELECT DISTINCT
+        i.CohortCode as procedureid,
+        j.SpecialtyCode || '|' as specialtycode
+    FROM
+        Base.CohortToSpecialty i
+        JOIN Base.Specialty j ON i.SpecialtyCode = j.SpecialtyCode
+        JOIN Base.ProviderToSpecialty k ON k.SpecialtyID = j.SpecialtyID
+    WHERE
+        k.SpecialtyIsRedundant = 0
+        AND k.IsSearchableCalculated = 1
+),
+
+cte_related_spec_xml2 as (
+    SELECT
+        procedureid,
+        listagg(iff(SpecialtyCode is not null, SpecialtyCode ,'')) AS XMLValue
+    FROM
+        cte_related_spec2
+    GROUP BY
+        procedureid
+),
+
+cte_related_parent_spec2 as (
+    SELECT distinct
+        i.cohortcode as procedureid,
+        j.SpecialtyCode || ':' || d1.PracticingSpecialtyCode || '|' AS SpecialtyCode
+    FROM
+        Base.CohortToSpecialty i
+        JOIN Base.Specialty j ON i.SpecialtyCode = j.SpecialtyCode
+        JOIN Base.ProviderToSpecialty k ON k.SpecialtyID = j.SpecialtyID
+        JOIN Base.SpecialtyGroupToSpecialty c1 ON j.SpecialtyID = c1.SpecialtyID
+        JOIN Base.SpecialtyGroup a1 ON a1.SpecialtyGroupID = c1.SpecialtyGroupID
+        JOIN Show.vwuPracticingSpecialtyToGroupSpecialtyPrimary d1 ON a1.SpecialtyGroupCode = d1.RolledUpSpecialtyCode
+    WHERE
+        j.IsPediatricAdolescent = 0
+        AND k.SpecialtyIsRedundant = 0
+        AND k.IsSearchableCalculated = 1
+        AND d1.PracticingSpecialtyCode <> j.SpecialtyCode
+),
+
+cte_related_parent_spec_xml2 as (
+    SELECT
+        procedureid,
+        listagg(iff(SpecialtyCode is not null, SpecialtyCode ,'')) AS XMLValue
+    FROM
+        cte_related_parent_spec2
+    GROUP BY
+        procedureid
+),
+
+
+cte_related_child_spec2 as (
+    SELECT distinct
+        i.CohortCode as procedureid,
+        j.SpecialtyCode || ':' || s.SpecialtyCode || '|' AS SpecialtyCode
+    FROM
+        Base.CohortToSpecialty i
+        JOIN Base.Specialty j ON i.SpecialtyCode = j.SpecialtyCode
+        JOIN Base.ProviderToSpecialty k ON k.SpecialtyID = j.SpecialtyID
+        JOIN Show.vwuPracticingSpecialtyToGroupSpecialtyPrimary d1 ON j.SpecialtyCode = d1.PracticingSpecialtyCode
+        JOIN Base.SpecialtyGroup a1 ON d1.RolledUpSpecialtyCode = a1.SpecialtyGroupCode
+        JOIN Base.SpecialtyGroupToSpecialty c1 ON a1.SpecialtyGroupID = c1.SpecialtyGroupID
+        JOIN Base.Specialty s ON s.SpecialtyID = c1.SpecialtyID
+    WHERE
+        j.IsPediatricAdolescent = 0
+        AND s.IsPediatricAdolescent = 0
+        AND k.SpecialtyIsRedundant = 0
+        AND k.IsSearchableCalculated = 1
+        AND j.SpecialtyCode <> s.SpecialtyCode
+),
+
+cte_related_child_spec_xml2 as (
+    SELECT
+        procedureid,
+        listagg(iff(SpecialtyCode is not null, SpecialtyCode ,'')) AS XMLValue
+    FROM
+        cte_related_child_spec2
+    GROUP BY
+        procedureid
+),
+
+
+cte_related_proc2 as (
+    SELECT DISTINCT
+        g.CohortCode as procedureid,
+        h.ProcedureCode || '|' as procedurecode
+    FROM
+        Base.CohortToProcedure g
+        JOIN Base.MedicalTerm i ON g.ProcedureMedicalID = i.MedicalTermID
+        JOIN CTE_ProviderProcedureXMLLoads h ON i.MedicalTermCode = h.ProcedureCode
+) ,
+
+cte_related_proc_xml2 as (
+    SELECT
+        procedureid,
+        listagg(iff(ProcedureCode is not null, ProcedureCode ,'')) AS XMLValue
+    FROM
+        cte_related_proc2
+    GROUP BY
+        procedureid
+),
+
+cte_related_cond2 AS (
+    SELECT DISTINCT
+        atc.cohortcode as procedureid,
+        pc.ConditionCode || '|' as conditioncode
+    FROM
+        Base.CohortToCondition atc
+        JOIN Base.MedicalTerm mt ON atc.ConditionID = mt.MedicalTermID
+        JOIN CTE_ProviderConditionXMLLoads pc ON mt.MedicalTermCode = pc.ConditionCode
+),
+
+cte_related_cond_xml2 AS (
+    SELECT
+        procedureid,
+        listagg(iff(ConditionCode is not null, ConditionCode ,'')) AS XMLValue
+    FROM
+        cte_related_cond2
+    GROUP BY
+        procedureid
+),
+cte_ratings AS (
+    SELECT DISTINCT 
+        fpr.facilityid,
+        proc.ProcedureID AS pCd, 
+        proc.ProcedureDescription AS pNm, 
+        'SL' || sl.ServiceLineID AS svcCd,
+        sl.ServiceLineDescription AS svcNm,
+        proc.RatingMethod AS rMth, 
+        CASE 
+            WHEN fpr.ProcedureID = 'OB1' THEN 1
+        END AS mcare,
+        fpr.DataYear AS rYr, 
+        fpr.DisplayDataYear AS rDispYr,
+        fpr.OverallSurvivalStar AS rStr, 
+        fpr.OverallRecovery30Star AS rStr30,
+        rspec.xmlvalue AS relatedspec,
+        rpar.xmlvalue AS relatedparentspec,
+        rchild.xmlvalue AS relatedchildspec,
+        rproc.xmlvalue AS relatedproc,
+        rcond.xmlvalue AS relatedcond
+    FROM	
+        ERMART1.Facility_FacilityToProcedureRating fpr
+        JOIN ERMART1.Facility_vwuFacilityHGDisplayProcedures vfdp ON fpr.ProcedureID = vfdp.ProcedureID AND fpr.RatingSourceID = vfdp.RatingSourceID
+        JOIN ERMART1.Facility_Procedure proc ON fpr.ProcedureID = proc.ProcedureID
+        JOIN ERMART1.Facility_ProcedureToServiceLine ptsl ON fpr.ProcedureID = ptsl.ProcedureID
+        JOIN ERMART1.Facility_ServiceLine sl ON ptsl.ServiceLineID = sl.ServiceLineID
+        JOIN Cte_Related_spec_xml2 AS rspec ON rspec.procedureid = proc.procedureid
+        JOIN Cte_Related_parent_Spec_xml2 AS rpar ON rpar.procedureid = proc.procedureid
+        JOIN cte_related_child_spec_xml2 AS rchild ON rchild.procedureid = proc.procedureid
+        JOIN Cte_related_proc_xml2 AS rproc ON rproc.procedureid = proc.procedureid
+        JOIN Cte_related_cond_xml2 AS rcond ON rcond.procedureid = proc.procedureid
+    WHERE	
+        fpr.IsMaxYear = 1
+),
+
+cte_ratings_xml as (
+    SELECT
+        facilityid,
+        '<procL>' || listagg('<proc>' || 
+        iff(pcd is not null,'<pcd>' || pcd || '</pcd>','') ||
+        iff(pnm is not null,'<pnm>' || pnm || '</pnm>','') ||
+        iff(svccd is not null,'<svccd>' || svccd || '</svccd>','') ||
+        iff(svcnm is not null,'<svcnm>' || svcnm || '</svcnm>','') ||
+        iff(rmth is not null,'<rmth>' || rmth || '</rmth>','') ||
+        iff(mcare is not null,'<mcare>' || mcare || '</mcare>','') ||
+        iff(ryr is not null,'<ryr>' || ryr || '</ryr>','') ||
+        iff(rdispyr is not null,'<rdispyr>' || rdispyr || '</rdispyr>','') ||
+        iff(rstr is not null,'<rstr>' || rstr || '</rstr>','') ||
+        iff(relatedspec is not null,'<relatedspec>' || relatedspec || '</relatedspec>','') ||
+        iff(relatedparentspec is not null,'<relatedparentspec>' || relatedparentspec || '</relatedparentspec>','') ||
+        iff(relatedchildspec is not null,'<relatedchildspec>' || relatedchildspec || '</relatedchildspec>','') ||
+        iff(relatedproc is not null,'<relatedproc>' || relatedproc || '</relatedproc>','') ||
+        iff(relatedcond is not null,'<relatedcond>' || relatedcond || '</relatedcond>','') || 
+        '</proc>', '') || '</procL>'
+ AS XMLValue
+    FROM
+        cte_ratings
+    GROUP BY
+        facilityid
+) 
+,
+
+cte_facility AS (
+SELECT distinct
+    pf.ProviderId,
+    pf.FacilityCode AS fID,
+    pf.LegacyKey AS fLegacyId,
+    pf.FacilityName AS fNm,
+    pf.ImageFilePath AS fLogo,
+    pf.HasAward AS awrd,
+    pf.AddressXML AS addrL,
+    pf.PDCPhoneXML AS pdcPhoneL,
+    pf.FacilityURL AS fUrl,
+    pf.FacilityType AS fType,
+    pf.FacilityTypeCode AS fTypeCd,
+    pf.FacilitySearchType AS fSearchTyp,
+    pf.FiveStarProcedureCount AS fiveStrCnt,
+    f.ImageXML AS imageL,
+    f.AwardCount AS awCnt,
+    f.MedicalServicesInformation AS medSvc,
+    fs.AnswerPercent AS patientSatis,
+    NULL AS topProcL,
+    CASE 
+        WHEN ps.ProductGroupCode = 'PDC' THEN '1'
+        ELSE '0'
+    END AS isPDC,
+    pf.qualityScore,
+    f.MissionStatement AS misson,
+    aw.xmlvalue as awardxml,
+    rat.xmlvalue as ratingsxml 
+FROM Mid.ProviderFacility AS pf
+    JOIN Mid.Facility f ON pf.FacilityID = f.FacilityID
+    JOIN Mid.Provider p ON p.ProviderID = pf.ProviderID
+    LEFT JOIN Mid.ProviderSponsorship ps ON p.ProviderCode = ps.ProviderCode AND f.FacilityCode = ps.FacilityCode
+    JOIN Cte_award_xml as aw on aw.facilityid = pf.legacykey
+    JOIN Cte_ratings_xml as rat on rat.facilityid = pf.legacykey
+    left join ERMART1.Facility_FacilityToSurvey fs on fs.FacilityID = f.LegacyKey and fs.SurveyID = 1 AND fs.QuestionID = 10
+),
+
+Cte_Facility_XML AS (
+SELECT
+        providerid,
+        '<facL>' || listagg('<fac>' || 
+        iff(fId is not null,'<fId>' || fId || '</fId>','') ||
+        iff(fLegacyId is not null,'<fLegacyId>' || fLegacyId || '</fLegacyId>','') ||
+        iff(fNm is not null,'<fNm>' || fNm || '</fNm>','') ||
+        iff(fLogo is not null,'<fLogo>' || fLogo || '</fLogo>','') ||
+        iff(awrd is not null,'<awrd>' || awrd || '</awrd>','') ||
+        iff(addrL is not null,'<addrL>' || addrL || '</addrL>','') ||
+        iff(pdcPhoneL is not null,'<pdcPhoneL>' || pdcPhoneL || '</pdcPhoneL>','') ||
+        iff(fUrl is not null,'<fUrl>' || fUrl || '</fUrl>','') ||
+        iff(fType is not null,'<fType>' || fType || '</fType>','') ||
+        iff(fTypeCd is not null,'<fTypeCd>' || fTypeCd || '</fTypeCd>','') ||
+        iff(fSearchTyp is not null,'<fSearchTyp>' || fSearchTyp || '</fSearchTyp>','') ||
+        iff(fiveStrCnt is not null,'<fiveStrCnt>' || fiveStrCnt || '</fiveStrCnt>','') ||
+        iff(imageL is not null,'<imageL>' || imageL || '</imageL>','') ||
+        iff(awCnt is not null,'<awCnt>' || awCnt || '</awCnt>','') ||
+        iff(medSvc is not null,'<medSvc>' || medSvc || '</medSvc>','') ||
+        iff(patientSatis is not null,'<patientSatis>' || patientSatis || '</patientSatis>','') ||
+        iff(topProcL is not null,'<topProcL>' || topProcL || '</topProcL>','') ||
+        iff(isPDC is not null,'<isPDC>' || isPDC || '</isPDC>','') ||
+        iff(qualityScore is not null,'<qualityScore>' || qualityScore || '</qualityScore>','') ||
+        iff(misson is not null,'<misson>' || replace(replace(misson, '<', ''), '>', '') || '</misson>','') ||
+        iff(awardxml is not null,'<awardxml>' || awardxml || '</awardxml>','') ||
+        iff(ratingsxml is not null,'<ratingsxml>' || ratingsxml || '</ratingsxml>','') || 
+        '</fac>', '') || '</facL>' 
+ AS XMLValue
+    FROM
+        cte_facility
+    GROUP BY
+        providerid
+) 
+select 
+    providerid,
+    to_variant(parse_xml(xmlvalue)) as facilityxml
+from cte_facility_xml $$;
+
+update_statement_facility := $$ update show.solrprovider as target
+                        set target.FacilityXML = source.facilityxml
+                        from ( $$ || select_statement_facility || $$ ) as source
+                        where target.ProviderID = source.ProviderID $$;
+
+
 ---------------------------------------------------------
 --------- 4. actions (inserts and updates) --------------
 ---------------------------------------------------------  
@@ -2235,6 +3537,13 @@ where
     execute immediate update_statement_23;
 end if;
 execute immediate update_statement_24;
+
+---------------------  XMLLOAD --------------------------
+
+execute immediate update_statement_xml_load_1;
+execute immediate update_statement_condition_hierarchy;
+execute immediate update_statement_cond_mapped;
+execute immediate update_statement_facility;
 
 ---------------------------------------------------------
 --------------- 6. status monitoring --------------------


### PR DESCRIPTION
It takes 36min to run. Added my part of xml load 
These are the affected columns:
availabilityxml (nulls within margin)
procedurehierarchyxml (nulls within margin)
conditionhierarchyxml (nulls within margin)
procmappedxml (nulls within margin)
condmappedxml (nulls within margin)
practicespecialtyhierxml (nulls within margin)
oasxml (nulls within margin)
facilityxml (nulls out of margin) -- all empty in snow
deaxml (nulls within margin)
emailaddressxml (nulls within margin)
degreexml (nulls within margin)
surveyxml (nulls within margin)
clinicalfocusdcpxml (nulls within margin) -- but all empty in snow
clinicalfocusxml (nulls within margin) -- but all empty in snow
trainingxml (nulls within margin)
lastupdatedatexml (no nulls)
smartreferralxml (nulls within margin) -- in snow we have all nulls because we dont have smart referral code coming from the json