### PR TITLE
show.solrproviderredirect

### DIFF
--- a/migration_original/ODS1Stage/tables/Show/SOLRProviderRedirect/SHOW.SOLRPROVIDERREDIRECT-report.md
+++ b/migration_original/ODS1Stage/tables/Show/SOLRProviderRedirect/SHOW.SOLRPROVIDERREDIRECT-report.md
@@ -1,0 +1,100 @@
+# SHOW.SOLRPROVIDERREDIRECT Report
+
+## 1. Sample Validation
+
+Percentage of Identical Columns: 91.43% (32/35).
+Percentage of Different Columns: 8.57% (3/35).
+
+The example below shows a sample row where values are not identical. Important to remember that fields like IDs are never expected to match. Long outputs are truncated since they will be hard to visualize.
+
+|    | Column Name            | Match ID   | SQL Server Value        | Snowflake Value               |
+|---:|:-----------------------|:-----------|:------------------------|:------------------------------|
+|  0 | SOLRPROVIDERREDIRECTID | 4BJML      | 445149                  | None                          |
+|  1 | UPDATEDATE             | 4BJML      | 2020-01-12 13:11:16.397 | 2024-06-28 16:04:36.926 -0700 |
+|  2 | UPDATESOURCE           | 4BJML      | dbo                     | CARRESE@RVOHEALTH.COM         |
+
+## 2. Aggregate Validation
+
+### 2.1 Total Columns
+- SQL Server: 35
+- Snowflake: 35
+- Columns Margin (%): 0.0
+
+### 2.2 Total Rows
+- SQL Server: 431259
+- Snowflake: 241327
+- Rows Margin (%): 44.041283776106695
+
+### 2.3 Nulls per Column
+|    | Column_Name            |   Total_Nulls_SQLServer |   Total_Nulls_Snowflake |   Margin (%) |
+|---:|:-----------------------|------------------------:|------------------------:|-------------:|
+|  0 | SOLRProviderRedirectID |                       0 |                  241327 |        inf   |
+|  1 | ProviderIDOld          |                  431258 |                  241327 |         44   |
+|  2 | ProviderIDNew          |                  431258 |                  241327 |         44   |
+|  3 | ProviderCodeOld        |                       0 |                       0 |          0   |
+|  4 | ProviderCodeNew        |                       0 |                       0 |          0   |
+|  5 | ProviderURLOld         |                       2 |                       1 |         50   |
+|  6 | ProviderURLNew         |                  222290 |                  174173 |         21.6 |
+|  7 | HGIDOld                |                  294244 |                  104371 |         64.5 |
+|  8 | HGIDNew                |                  289985 |                  100113 |         65.5 |
+|  9 | HGID8Old               |                  297743 |                  107869 |         63.8 |
+| 10 | HGID8New               |                  297734 |                  107860 |         63.8 |
+| 11 | LastName               |                      17 |                       0 |        100   |
+| 12 | FirstName              |                      20 |                       1 |         95   |
+| 13 | MiddleName             |                   86004 |                   52162 |         39.3 |
+| 14 | Suffix                 |                  377835 |                  197584 |         47.7 |
+| 15 | DisplayName            |                   40510 |                   40486 |          0.1 |
+| 16 | Degree                 |                  344408 |                  241327 |         29.9 |
+| 17 | Title                  |                  348356 |                  241327 |         30.7 |
+| 18 | DegreePriority         |                  431259 |                  241327 |         44   |
+| 19 | ProviderTypeID         |                  289112 |                  241327 |         16.5 |
+| 20 | ProviderTypeGroup      |                  289099 |                  241327 |         16.5 |
+| 21 | CityState              |                  431259 |                  241327 |         44   |
+| 22 | SpecialtyCode          |                  431259 |                  241327 |         44   |
+| 23 | SpecialtyLegacyKey     |                  431259 |                  241327 |         44   |
+| 24 | DeactivationReason     |                       7 |                       7 |          0   |
+| 25 | Gender                 |                  389617 |                  241327 |         38.1 |
+| 26 | DateOfBirth            |                  379549 |                  241327 |         36.4 |
+| 27 | PracticeOfficeXML      |                  324941 |                  241327 |         25.7 |
+| 28 | SpecialtyXML           |                  355384 |                  241327 |         32.1 |
+| 29 | EducationXML           |                  390268 |                  241327 |         38.2 |
+| 30 | ImageXML               |                  431245 |                  241327 |         44   |
+| 31 | ExpireCode             |                  431246 |                  241327 |         44   |
+| 32 | LastUpdateDate         |                      14 |                       0 |        100   |
+| 33 | UpdateDate             |                      14 |                       0 |        100   |
+| 34 | UpdateSource           |                      14 |                       0 |        100   |
+
+### 2.4 Distincts per Column
+|    | Column_Name            |   Total_Distincts_SQLServer |   Total_Distincts_Snowflake |   Margin (%) |
+|---:|:-----------------------|----------------------------:|----------------------------:|-------------:|
+|  0 | SOLRProviderRedirectID |                      431259 |                           0 |        100   |
+|  1 | ProviderIDOld          |                           1 |                           0 |        100   |
+|  2 | ProviderIDNew          |                           1 |                           0 |        100   |
+|  3 | ProviderCodeOld        |                      431257 |                      241327 |         44   |
+|  4 | ProviderCodeNew        |                      430737 |                      240832 |         44.1 |
+|  5 | ProviderURLOld         |                      431247 |                      241321 |         44   |
+|  6 | ProviderURLNew         |                      208477 |                       66685 |         68   |
+|  7 | HGIDOld                |                      136886 |                      136830 |          0   |
+|  8 | HGIDNew                |                      140713 |                      140660 |          0   |
+|  9 | HGID8Old               |                      133512 |                      133455 |          0   |
+| 10 | HGID8New               |                      133389 |                      133326 |          0   |
+| 11 | LastName               |                      121905 |                       87807 |         28   |
+| 12 | FirstName              |                       38305 |                       30030 |         21.6 |
+| 13 | MiddleName             |                       28651 |                       19285 |         32.7 |
+| 14 | Suffix                 |                          15 |                          22 |         46.7 |
+| 15 | DisplayName            |                      344163 |                      164867 |         52.1 |
+| 16 | Degree                 |                         307 |                           0 |        100   |
+| 17 | Title                  |                           1 |                           0 |        100   |
+| 18 | DegreePriority         |                           0 |                           0 |          0   |
+| 19 | ProviderTypeID         |                           6 |                           0 |        100   |
+| 20 | ProviderTypeGroup      |                           3 |                           0 |        100   |
+| 21 | CityState              |                           0 |                           0 |          0   |
+| 22 | SpecialtyCode          |                           0 |                           0 |          0   |
+| 23 | SpecialtyLegacyKey     |                           0 |                           0 |          0   |
+| 24 | DeactivationReason     |                           4 |                           4 |          0   |
+| 25 | Gender                 |                           2 |                           0 |        100   |
+| 26 | DateOfBirth            |                       17762 |                           0 |        100   |
+| 27 | ExpireCode             |                           2 |                           0 |        100   |
+| 28 | LastUpdateDate         |                        1945 |                        1831 |          5.9 |
+| 29 | UpdateDate             |                         239 |                           1 |         99.6 |
+| 30 | UpdateSource           |                          10 |                           1 |         90   |

--- a/migration_original/ODS1Stage/tables/Show/SOLRProviderRedirect/spu_translated_SOLRProviderRedirect.sql
+++ b/migration_original/ODS1Stage/tables/Show/SOLRProviderRedirect/spu_translated_SOLRProviderRedirect.sql
@@ -19,6 +19,7 @@ declare
 ---------------------------------------------------------
 
     select_statement string; -- cte statement
+    select_statement_1 string; 
     merge_condition string; -- merge condition to final table
     update_statement string; -- update statement to final table
     insert_statement string; -- insert statement to final table
@@ -29,122 +30,120 @@ declare
     status string; -- status monitoring
     procedure_name varchar(50) default('sp_load_solrproviderredirect');
     execution_start datetime default getdate();
-
-
    
 begin   
-        
-                                
-
 
 ---------------------------------------------------------
 ----------------- 3. sql statements ---------------------
 ---------------------------------------------------------     
-
-
         
-select_statement := ' with cte_providernotinsolr as (
-                        	select	providercodeold 
-                        			,providercodenew 
-                        			,providerurlold 
-                        			,providerurlnew 
-                        			,hgidold 
-                        			,hgidnew 
-                        			,hgid8old 
-                        			,hgid8new 
-                        			,lastname 
-                        			,firstname 
-                        			,middlename 
-                        			,suffix 
-                        			,displayname 
-                        			,degree 
-                        			,degreepriority 
-                        			,providertypeid 
-                        			,citystate
-                        			,specialtycode
-                        			,specialtylegacykey
-                        			,deactivationreason
-                        			,lastupdatedate 
-                        			,row_number() over(partition by providercodeold order by lastupdatedate desc) as sequenceid
-                        	from	base.providerredirect
-                        	where	providercodeold not in (select providercode from show.solrprovider )
-                        )
-                        
-    
-                            select	providercodeold 
-                        			,providercodenew 
-                        			,providerurlold 
-                        			,providerurlnew 
-                        			,hgidold 
-                        			,hgidnew 
-                        			,hgid8old 
-                        			,hgid8new 
-                        			,lastname 
-                        			,firstname 
-                        			,middlename 
-                        			,suffix 
-                        			,displayname 
-                        			,degree 
-                        			,degreepriority 
-                        			,providertypeid 
-                        			,citystate
-                        			,specialtycode
-                        			,specialtylegacykey
-                        			,deactivationreason
-                        			,lastupdatedate 
-                            from cte_providernotinsolr
-                            where sequenceid = 1
-                            ';
+select_statement := $$ select distinct
+                            providercodeold,
+                            providercodenew,
+                            providerurlold,
+                            providerurlnew,
+                            hgidold,
+                            hgidnew,
+                            hgid8old,
+                            hgid8new,
+                            lastname,
+                            firstname,
+                            middlename,
+                            suffix,
+                            displayname,
+                            degree,
+                            degreepriority,
+                            providertypeid,
+                            citystate,
+                            specialtycode,
+                            specialtylegacykey,
+                            case when deactivationreason = 'duplicate' then 'Duplicate' else deactivationreason end as deactivationreason,
+                            lastupdatedate,
+                            null as title,
+                            null as gender,
+                            null as updatedate,
+                            null as updatesource,
+                            null as providertypegroup,
+                            null as dateofbirth,
+                            null as practiceofficexml,
+                            null as specialtyxml,
+                            null as educationxml,
+                            null as imagexml,
+                    from	base.providerredirect
+                    where	providercodeold not in (select providercode from show.solrprovider )
+                    qualify row_number() over(partition by providercodeold order by lastupdatedate desc) = 1
+                    $$;
 
-merge_condition := '  ctefinal.providercodeold != solrprovred.providercodeold
-                or ctefinal.providercodenew != solrprovred.providercodenew
-                or ctefinal.providerurlold != solrprovred.providerurlold
-                or ctefinal.providerurlnew != solrprovred.providerurlnew
-                or ctefinal.hgidold != solrprovred.hgidold
-                or ctefinal.hgidnew != solrprovred.hgidnew
-                or ctefinal.hgid8old != solrprovred.hgid8old
-                or ctefinal.hgid8new != solrprovred.hgid8new
-                or ctefinal.lastname != solrprovred.lastname
-                or ctefinal.firstname != solrprovred.firstname
-                or ctefinal.middlename != solrprovred.middlename
-                or ctefinal.suffix != solrprovred.suffix
-                or ctefinal.displayname != solrprovred.displayname
-                or ctefinal.degree != solrprovred.degree
-                or ctefinal.degreepriority != solrprovred.degreepriority
-                or ctefinal.providertypeid != solrprovred.providertypeid
-                or ctefinal.citystate != solrprovred.citystate
-                or ctefinal.specialtycode != solrprovred.specialtycode
-                or ctefinal.specialtylegacykey != solrprovred.specialtylegacykey
-                or ctefinal.deactivationreason != solrprovred.deactivationreason
-                or ctefinal.lastupdatedate != solrprovred.lastupdatedate';
+select_statement_1 := $$select
+                        solrprov.providercode as providercodeold,
+                        solrprov.providercode as providercodenew,
+                        solrprov.providerurl as providerurlold,
+                        solrprov.providerurl as providerurlnew,
+                        solrprov.lastname,
+                        solrprov.firstname,
+                        solrprov.middlename,
+                        solrprov.suffix,
+                        solrprov.firstname || ' ' || iff(solrprov.middlename is null, '', solrprov.middlename || ' ') || solrprov.lastname || iff(solrprov.suffix is null,'', ' ' || solrprov.suffix) as displayname,
+                        solrprov.degree,
+                        solrprov.title,
+                        solrprov.providertypeid,
+                        solrprov.providertypegroup,
+                        'Deactivated' as deactivationreason,
+                        solrprov.gender as gender,
+                        solrprov.dateofbirth,
+                        solrprov.practiceofficexml,
+                        solrprov.specialtyxml,
+                        solrprov.educationxml,
+                        solrprov.imagexml,
+                        current_timestamp() as lastupdatedate,
+                        current_timestamp() as updatedate,
+                        current_user() as updatesource,
+                        solrprovred.hgidold,
+                        solrprovred.hgidnew,
+                        solrprovred.hgid8old,
+                        solrprovred.hgid8new,
+                        solrprovred.degreepriority,
+                        solrprovred.citystate,
+                        solrprovred.specialtycode,
+                        solrprovred.specialtylegacykey  
+                    from
+                        show.solrprovider solrprov
+                        join base.provider baseprov on baseprov.providerid = solrprov.providerid
+                        left join show.solrproviderredirect solrprovred on solrprovred.providercodeold = solrprov.providercode
+                        and solrprovred.providercodenew = solrprov.providercode
+                        and solrprovred.deactivationreason = 'Deactivated'
+                    where
+                        solrprovred.solrproviderredirectid is null
+                    qualify row_number() over(partition by providercodeold order by current_timestamp() desc) = 1 $$;
 
 update_statement := 'update
                         set
-                            providercodeold = ctefinal.providercodeold,
-                            providercodenew = ctefinal.providercodenew,
-                            providerurlold = ctefinal.providerurlold,
-                            providerurlnew = ctefinal.providerurlnew,
-                            hgidold = ctefinal.hgidold,
-                            hgidnew = ctefinal.hgidnew,
-                            hgid8old = ctefinal.hgid8old,
-                            hgid8new = ctefinal.hgid8new,
-                            lastname = ctefinal.lastname,
-                            firstname = ctefinal.firstname,
-                            middlename = ctefinal.middlename,
-                            suffix = ctefinal.suffix,
-                            displayname = ctefinal.displayname,
-                            degree = ctefinal.degree,
-                            degreepriority = ctefinal.degreepriority,
-                            providertypeid = ctefinal.providertypeid,
-                            citystate = ctefinal.citystate,
-                            specialtycode = ctefinal.specialtycode,
-                            specialtylegacykey = ctefinal.specialtylegacykey,
-                            deactivationreason = ctefinal.deactivationreason,
-                            lastupdatedate = ctefinal.lastupdatedate,
+                            providercodeold = source.providercodeold,
+                            providercodenew = source.providercodenew,
+                            providerurlold = source.providerurlold,
+                            providerurlnew = source.providerurlnew,
+                            hgidold = source.hgidold,
+                            hgidnew = source.hgidnew,
+                            hgid8old = source.hgid8old,
+                            hgid8new = source.hgid8new,
+                            lastname = source.lastname,
+                            firstname = source.firstname,
+                            middlename = source.middlename,
+                            suffix = source.suffix,
+                            displayname = source.displayname,
+                            degree = source.degree,
+                            degreepriority = source.degreepriority,
+                            providertypeid = source.providertypeid,
+                            citystate = source.citystate,
+                            specialtycode = source.specialtycode,
+                            specialtylegacykey = source.specialtylegacykey,
+                            deactivationreason = source.deactivationreason,
+                            lastupdatedate = source.lastupdatedate,
                             updatedate = current_timestamp(),
                             updatesource = current_user()';
 
  insert_statement := 'insert(
+                        solrproviderredirectid,
                         providercodeold,
                         providercodenew,
                         providerurlold,
@@ -167,124 +166,71 @@ update_statement := 'update
                         deactivationreason,
                         lastupdatedate,
                         updatedate,
-                        updatesource
+                        updatesource,
+                        title,
+                        providertypegroup,
+                        gender,
+                        dateofbirth,
+                        practiceofficexml,
+                        specialtyxml,
+                        educationxml,
+                        imagexml
                     )
                     values
-                    (ctefinal.providercodeold,
-                        ctefinal.providercodenew,
-                        ctefinal.providerurlold,
-                        ctefinal.providerurlnew,
-                        ctefinal.hgidold,
-                        ctefinal.hgidnew,
-                        ctefinal.hgid8old,
-                        ctefinal.hgid8new,
-                        ctefinal.lastname,
-                        ctefinal.firstname,
-                        ctefinal.middlename,
-                        ctefinal.suffix,
-                        ctefinal.displayname,
-                        ctefinal.degree,
-                        ctefinal.degreepriority,
-                        ctefinal.providertypeid,
-                        ctefinal.citystate,
-                        ctefinal.specialtycode,
-                        ctefinal.specialtylegacykey,
-                        ctefinal.deactivationreason,
-                        ctefinal.lastupdatedate,
+                        (uuid_string(),
+                        source.providercodeold,
+                        source.providercodenew,
+                        source.providerurlold,
+                        source.providerurlnew,
+                        source.hgidold,
+                        source.hgidnew,
+                        source.hgid8old,
+                        source.hgid8new,
+                        source.lastname,
+                        source.firstname,
+                        source.middlename,
+                        source.suffix,
+                        source.displayname,
+                        source.degree,
+                        source.degreepriority,
+                        source.providertypeid,
+                        source.citystate,
+                        source.specialtycode,
+                        source.specialtylegacykey,
+                        source.deactivationreason,
+                        source.lastupdatedate,
                         current_timestamp(),
-                        current_user() );';
+                        current_user(),
+                        source.title,
+                        source.providertypegroup,
+                        source.gender,
+                        source.dateofbirth,
+                        source.practiceofficexml,
+                        source.specialtyxml,
+                        source.educationxml,
+                        source.imagexml );';
 
-merge_statement_else_1 := 'merge into show.solrproviderredirect as target
-                                    using (
-                                        select
-                                            solrprov.providercode as providercodeold,
-                                            solrprov.providercode as providercodenew,
-                                            solrprov.providerurl as providerurlold,
-                                            solrprov.providerurl as providerurlnew,
-                                            solrprov.lastname,
-                                            solrprov.firstname,
-                                            solrprov.middlename,
-                                            solrprov.suffix,
-                                            solrprov.firstname || '' '' || iff(solrprov.middlename is null, '''', solrprov.middlename || '' '') || solrprov.lastname || iff(solrprov.suffix is null,'''', '' '' || solrprov.suffix) as displayname,
-                                            solrprov.degree,
-                                            solrprov.title,
-                                            solrprov.providertypeid,
-                                            solrprov.providertypegroup,
-                                            ''deactivated'' as deactivationreason,
-                                            solrprov.gender as gender,
-                                            solrprov.dateofbirth,
-                                            solrprov.practiceofficexml,
-                                            solrprov.specialtyxml,
-                                            solrprov.educationxml,
-                                            solrprov.imagexml,
-                                            current_timestamp() as lastupdatedate,
-                                            current_timestamp() as updatedate,
-                                            current_user() as updatesource
-                                        from
-                                            show.solrprovider solrprov
-                                            left join base.provider baseprov on baseprov.providerid = solrprov.providerid
-                                            left join show.solrproviderredirect solrprovred on solrprovred.providercodeold = solrprov.providercode
-                                            and solrprovred.providercodenew = solrprov.providercode
-                                            and solrprovred.deactivationreason = ''deactivated''
-                                        where
-                                            baseprov.providerid is null
-                                            and solrprovred.solrproviderredirectid is null
-                                    ) as source
-                                    on target.providercodeold = source.providercodeold
-                                    when not matched then 
-                                        insert (
-                                            providercodeold,
-                                            providercodenew,
-                                            providerurlold,
-                                            providerurlnew,
-                                            lastname,
-                                            firstname,
-                                            middlename,
-                                            suffix,
-                                            displayname,
-                                            degree,
-                                            title,
-                                            providertypeid,
-                                            providertypegroup,
-                                            deactivationreason,
-                                            gender,
-                                            dateofbirth,
-                                            practiceofficexml,
-                                            specialtyxml,
-                                            educationxml,
-                                            imagexml,
-                                            lastupdatedate,
-                                            updatedate,
-                                            updatesource
-                                        )
-                                        values (
-                                            source.providercodeold,
-                                            source.providercodenew,
-                                            source.providerurlold,
-                                            source.providerurlnew,
-                                            source.lastname,
-                                            source.firstname,
-                                            source.middlename,
-                                            source.suffix,
-                                            source.displayname,
-                                            source.degree,
-                                            source.title,
-                                            source.providertypeid,
-                                            source.providertypegroup,
-                                            source.deactivationreason,
-                                            source.gender,
-                                            source.dateofbirth,
-                                            source.practiceofficexml,
-                                            source.specialtyxml,
-                                            source.educationxml,
-                                            source.imagexml,
-                                            source.lastupdatedate,
-                                            source.updatedate,
-                                            source.updatesource
-                                        );';
+   
+                
+---------------------------------------------------------
+--------- 4. actions (inserts and updates) --------------
+---------------------------------------------------------  
+                     
+
+    merge_statement := 'merge into show.solrproviderredirect as target
+                        using ('  || select_statement || ') as source 
+                        on source.providercodeold = target.providercodeold and source.providercodenew = target.providercodenew
+                        when matched then ' || update_statement ||
+                        'when not matched then ' || insert_statement;
+
+    -- this gives no rows in sql server, it does not insert anything
+    merge_statement_else_1 := $$ merge into show.solrproviderredirect as target
+                                using ( $$  || select_statement_1 || $$  ) as source
+                                on source.providercodenew = target.providercodenew
+                                when not matched then $$ || insert_statement;
                                                                 
             
-                        
+     -- this updates the urlold column                   
      merge_statement_else_2 := 'merge into show.solrproviderredirect as solrprovred using (
                                  select
                                     provurl.url,
@@ -294,26 +240,11 @@ merge_statement_else_1 := 'merge into show.solrproviderredirect as target
                                     join base.provider as baseprov on provurl.providerid = baseprov.providerid
                            ) as url on solrprovred.providercodeold = url.providercode
                             and solrprovred.providerurlold is null
-                            when matched then
-                        update
-                        set
-                            solrprovred.providerurlold = url.url;';
-                
----------------------------------------------------------
---------- 4. actions (inserts and updates) --------------
----------------------------------------------------------  
-                     
-
-merge_statement := 'merge into show.solrproviderredirect as solrprovred
-                        using ('  || select_statement || ') as ctefinal 
-                        on ctefinal.providercodeold = solrprovred.providercodeold
-                        when matched and (' || merge_condition ||') then '
-                            || update_statement ||
-                        'when not matched then '
-                            || insert_statement;
+                            when matched then update set
+                            solrprovred.providerurlold = url.url;';                            
 
                          
-delete_statement := 'delete from
+    delete_statement := 'delete from
                 show.solrproviderredirect
             where
                 providercodeold in (
@@ -321,9 +252,7 @@ delete_statement := 'delete from
                         providercode
                     from
                         show.solrprovider);';
-
-                    
-                        
+                       
 
 ---------------------------------------------------------
 -------------------  5. execution ------------------------
@@ -332,9 +261,9 @@ delete_statement := 'delete from
 if (is_full) then
     truncate table Show.SOLRProviderRedirect;
 end if; 
+execute immediate merge_statement;
 execute immediate merge_statement_else_1;
 execute immediate merge_statement_else_2;
-execute immediate merge_statement;
 execute immediate delete_statement;
 
 ---------------------------------------------------------


### PR DESCRIPTION
within margins. We have less rows because there are less deprecated rows. the rest of categories have the same count