### PR TITLE
Base.ProviderMedia Delta Fix

### DIFF
--- a/migration_original/ODS1Stage/tables/Base/ProviderMedia/spu_translated_ProviderMedia.sql
+++ b/migration_original/ODS1Stage/tables/Base/ProviderMedia/spu_translated_ProviderMedia.sql
@@ -19,7 +19,7 @@ declare
 
     select_statement string; -- cte and select statement for the merge
     insert_statement string; -- insert statement for the merge
-    delete_statement string; -- update
+    update_statement string; -- update
     merge_statement string; -- merge statement to final table
     status string; -- status monitoring
     procedure_name varchar(50) default('sp_load_providermedia');
@@ -47,7 +47,7 @@ SELECT
 FROM $$||mdm_db||$$.mst.provider_profile_processing as p
 , lateral flatten(input => p.PROVIDER_PROFILE:MEDIA) as json
 )
-select distinct
+select
     p.providerid,
     mt.mediatypeid,
     json.media_MEDIADATE as MediaDate,
@@ -64,34 +64,39 @@ from cte_media as JSON
 qualify row_number() over(partition by ProviderID, media_mediatypecode, media_mediadate, media_MediaLink, media_MediaPublisher, media_MediaSynopsis, media_MediaTitle order by json.media_lastupdatedate desc) = 1 $$;
 
 --- insert Statement
-insert_statement := ' insert  
-                            (ProviderMediaId, 
-                            ProviderID,
-                            MediaTypeID,
-                            MediaDate,
-                            MediaTitle,
-                            MediaPublisher,
-                            MediaSynopsis,
-                            MediaLink,
-                            SourceCode,
-                            LastUpdateDate)         
-                     values 
-                            (uuid_string(), 
-                            source.providerid,
-                            source.mediatypeid,
-                            source.mediadate,
-                            source.mediatitle,
-                            source.mediapublisher,
-                            source.mediasynopsis,
-                            source.medialink,
-                            source.sourcecode,
-                            source.lastupdatedate)';
-                            
---- delete statement
-delete_statement := 'delete from base.providermedia as target
-                    using (' || select_statement || ') as source
-                    where source.providerid = target.providerid
-                        and source.mediatypeid = target.mediatypeid';
+insert_statement := '       insert  
+                                    (ProviderMediaId, 
+                                    ProviderID,
+                                    MediaTypeID,
+                                    MediaDate,
+                                    MediaTitle,
+                                    MediaPublisher,
+                                    MediaSynopsis,
+                                    MediaLink,
+                                    SourceCode,
+                                    LastUpdateDate)         
+                             values 
+                                    (utils.generate_uuid(source.providerid || source.mediatypeid), 
+                                    source.providerid,
+                                    source.mediatypeid,
+                                    source.mediadate,
+                                    source.mediatitle,
+                                    source.mediapublisher,
+                                    source.mediasynopsis,
+                                    source.medialink,
+                                    source.sourcecode,
+                                    source.lastupdatedate)';
+--- update statement
+update_statement := ' 
+    update
+    set
+        target.MediaDate = source.mediadate,
+        target.MediaTitle = source.mediatitle,
+        target.MediaPublisher = source.mediapublisher,
+        target.MediaSynopsis = source.mediasynopsis,
+        target.MediaLink = source.medialink,
+        target.SourceCode = source.sourcecode,
+        target.LastUpdateDate = source.lastupdatedate';
         
 ---------------------------------------------------------
 --------- 4. actions (inserts and updates) --------------
@@ -99,9 +104,15 @@ delete_statement := 'delete from base.providermedia as target
 
 merge_statement := 'merge into base.providermedia as target 
                     using (' || select_statement || ') as source
-                        on source.providerid = target.providerid 
-                        and source.mediatypeid = target.mediatypeid
-                    when not matched then '||insert_statement;
+                   on source.providerid = target.providerid 
+                    and source.mediatypeid = target.mediatypeid
+                    and source.mediatitle = target.mediatitle
+                    and source.medialink = target.medialink
+                    and source.mediapublisher = target.mediapublisher
+                    and source.mediasynopsis = target.mediasynopsis
+                    and source.lastupdatedate = target.lastupdatedate
+                   when matched then ' || update_statement || '
+                   when not matched then '||insert_statement;
 
 ---------------------------------------------------------
 -------------------  5. execution ------------------------
@@ -110,7 +121,6 @@ merge_statement := 'merge into base.providermedia as target
 if (is_full) then
     truncate table Base.ProviderMedia;
 end if; 
-execute immediate delete_statement ;
 execute immediate merge_statement ;
 
 ---------------------------------------------------------


### PR DESCRIPTION
This one required a slightly different approach. The original procedure does not have an update logic, it simply deletes matching ProviderIDs and inserts them again. Inventing an update statement does not make sense to me since we have no way of knowing which columns may change (+ the PK is generated randomly in SQL Server).